### PR TITLE
feat: SQL-based balance calculation (#9)

### DIFF
--- a/src/ledger/api/dependencies.py
+++ b/src/ledger/api/dependencies.py
@@ -64,21 +64,15 @@ def get_account_service(
         account_repo.SqlaAccountRepository,
         fastapi.Depends(get_account_repository),
     ],
-    transaction_repository: typing.Annotated[
-        transaction_repo.SqlaTransactionRepository,
-        fastapi.Depends(get_transaction_repository),
-    ],
 ) -> account_service.AccountService:
     """
     Build an account service wired with repositories.
 
     :param account_repository: account repository instance
-    :param transaction_repository: transaction repository instance
     :return: account service instance
     """
     return account_service.AccountService(
         account_repo=account_repository,
-        transaction_repo=transaction_repository,
     )
 
 

--- a/src/ledger/application/account_service.py
+++ b/src/ledger/application/account_service.py
@@ -8,7 +8,6 @@ import ledger.application.interfaces as interfaces
 import ledger.domain.enums as enums
 import ledger.domain.exceptions as exceptions
 import ledger.domain.models as models
-import ledger.domain.services as domain_services
 
 
 @dataclasses.dataclass(frozen=True)
@@ -25,16 +24,13 @@ class AccountService:
     def __init__(
         self,
         account_repo: interfaces.AccountRepository,
-        transaction_repo: interfaces.TransactionRepository,
     ) -> None:
         """
         Initialise the service with repository dependencies.
 
         :param account_repo: account persistence interface
-        :param transaction_repo: transaction persistence interface
         """
         self._account_repo = account_repo
-        self._transaction_repo = transaction_repo
 
     async def create_account(
         self,
@@ -66,43 +62,27 @@ class AccountService:
 
     async def get_by_id(self, account_id: uuid.UUID) -> AccountWithBalance:
         """
-        Retrieve an account by ID and compute its balance.
+        Retrieve an account by ID with its balance computed via SQL aggregation.
 
         :param account_id: UUID of the account
         :return: account with computed balance
         :raises AccountNotFoundError: if the account does not exist
         """
-        account = await self._account_repo.get_by_id(account_id)
-        if account is None:
+        result = await self._account_repo.get_with_balance(account_id)
+        if result is None:
             raise exceptions.AccountNotFoundError(f"Account {account_id} not found")
 
-        balance = await self._compute_balance(account)
+        account, balance = result
         return AccountWithBalance(account=account, balance=balance)
 
     async def get_all(self) -> list[AccountWithBalance]:
         """
-        Retrieve all accounts with computed balances.
+        Retrieve all accounts with balances computed via SQL aggregation.
 
         :return: list of accounts with their balances
         """
-        accounts = await self._account_repo.get_all()
-        results: list[AccountWithBalance] = []
-        for account in accounts:
-            balance = await self._compute_balance(account)
-            results.append(AccountWithBalance(account=account, balance=balance))
-        return results
-
-    async def _compute_balance(self, account: models.Account) -> decimal.Decimal:
-        """
-        Compute the current balance for an account from its transaction entries.
-
-        :param account: the account to compute balance for
-        :return: computed balance as Decimal
-        """
-        transactions = await self._transaction_repo.get_by_account_id(account.id)
-        entries: list[models.TransactionEntry] = []
-        for txn in transactions:
-            for entry in txn.entries:
-                if entry.account_id == account.id:
-                    entries.append(entry)
-        return domain_services.calculate_balance(account.type, entries)
+        results = await self._account_repo.get_all_with_balances()
+        return [
+            AccountWithBalance(account=account, balance=balance)
+            for account, balance in results
+        ]

--- a/src/ledger/application/interfaces.py
+++ b/src/ledger/application/interfaces.py
@@ -1,5 +1,6 @@
 """Repository interfaces defining data-access contracts for the application layer."""
 
+import decimal
 import typing
 import uuid
 
@@ -42,6 +43,27 @@ class AccountRepository(typing.Protocol):
 
         :param account_id: UUID of the account
         :return: True if the account exists, False otherwise
+        """
+        ...
+
+    async def get_with_balance(
+        self, account_id: uuid.UUID
+    ) -> tuple[models.Account, decimal.Decimal] | None:
+        """
+        Retrieve an account with its computed balance via SQL aggregation.
+
+        :param account_id: UUID of the account
+        :return: tuple of (account, balance), or None if not found
+        """
+        ...
+
+    async def get_all_with_balances(
+        self,
+    ) -> list[tuple[models.Account, decimal.Decimal]]:
+        """
+        Retrieve all accounts with their computed balances via SQL aggregation.
+
+        :return: list of (account, balance) tuples
         """
         ...
 

--- a/src/ledger/infrastructure/repositories/account_repo.py
+++ b/src/ledger/infrastructure/repositories/account_repo.py
@@ -1,11 +1,13 @@
 """SQLAlchemy-based account repository implementation."""
 
+import decimal
 import uuid
 
 import sqlalchemy as sa
 import sqlalchemy.exc as sa_exc
 import sqlalchemy.ext.asyncio as sa_async
 
+import ledger.domain.enums as enums
 import ledger.domain.exceptions as exceptions
 import ledger.domain.models as models
 import ledger.infrastructure.mappers as mappers
@@ -75,3 +77,131 @@ class SqlaAccountRepository:
         stmt = sa.select(sa.exists().where(orm_models.AccountModel.id == account_id))
         result = await self._session.execute(stmt)
         return bool(result.scalar())
+
+    async def get_with_balance(
+        self, account_id: uuid.UUID
+    ) -> tuple[models.Account, decimal.Decimal] | None:
+        """
+        Retrieve an account with its computed balance via SQL aggregation.
+
+        :param account_id: UUID of the account
+        :return: tuple of (account, balance), or None if not found
+        """
+        stmt = (
+            sa.select(
+                orm_models.AccountModel.id,
+                orm_models.AccountModel.name,
+                orm_models.AccountModel.account_type,
+                self._balance_expression(),
+            )
+            .outerjoin(
+                orm_models.TransactionEntryModel,
+                orm_models.TransactionEntryModel.account_id
+                == orm_models.AccountModel.id,
+            )
+            .where(orm_models.AccountModel.id == account_id)
+            .group_by(
+                orm_models.AccountModel.id,
+                orm_models.AccountModel.name,
+                orm_models.AccountModel.account_type,
+            )
+        )
+        result = await self._session.execute(stmt)
+        row = result.one_or_none()
+        if row is None:
+            return None
+        else:
+            account = models.Account(
+                id=row.id,
+                name=row.name,
+                type=enums.AccountType(row.account_type),
+            )
+            return account, row.balance
+
+    async def get_all_with_balances(
+        self,
+    ) -> list[tuple[models.Account, decimal.Decimal]]:
+        """
+        Retrieve all accounts with their computed balances via SQL aggregation.
+
+        :return: list of (account, balance) tuples
+        """
+        stmt = (
+            sa.select(
+                orm_models.AccountModel.id,
+                orm_models.AccountModel.name,
+                orm_models.AccountModel.account_type,
+                self._balance_expression(),
+            )
+            .outerjoin(
+                orm_models.TransactionEntryModel,
+                orm_models.TransactionEntryModel.account_id
+                == orm_models.AccountModel.id,
+            )
+            .group_by(
+                orm_models.AccountModel.id,
+                orm_models.AccountModel.name,
+                orm_models.AccountModel.account_type,
+            )
+        )
+        result = await self._session.execute(stmt)
+        return [
+            (
+                models.Account(
+                    id=row.id,
+                    name=row.name,
+                    type=enums.AccountType(row.account_type),
+                ),
+                row.balance,
+            )
+            for row in result.all()
+        ]
+
+    @staticmethod
+    def _balance_expression() -> sa.Label[decimal.Decimal]:
+        """
+        Build a SQLAlchemy expression for balance computation.
+
+        ASSET and EXPENSE are debit-normal (debits - credits).
+        LIABILITY and REVENUE are credit-normal (credits - debits).
+
+        :return: labelled SQL expression computing the balance
+        """
+        debit_sum = sa.func.coalesce(
+            sa.func.sum(
+                sa.case(
+                    (
+                        orm_models.TransactionEntryModel.entry_type
+                        == enums.EntryType.DEBIT.value,
+                        orm_models.TransactionEntryModel.amount,
+                    ),
+                    else_=0,
+                )
+            ),
+            0,
+        )
+        credit_sum = sa.func.coalesce(
+            sa.func.sum(
+                sa.case(
+                    (
+                        orm_models.TransactionEntryModel.entry_type
+                        == enums.EntryType.CREDIT.value,
+                        orm_models.TransactionEntryModel.amount,
+                    ),
+                    else_=0,
+                )
+            ),
+            0,
+        )
+        return sa.case(
+            (
+                orm_models.AccountModel.account_type.in_(
+                    [
+                        enums.AccountType.ASSET.value,
+                        enums.AccountType.EXPENSE.value,
+                    ]
+                ),
+                debit_sum - credit_sum,
+            ),
+            else_=credit_sum - debit_sum,
+        ).label("balance")

--- a/tests/api/test_accounts_api.py
+++ b/tests/api/test_accounts_api.py
@@ -159,3 +159,83 @@ async def test_get_account_not_found(client: httpx.AsyncClient) -> None:
 
     assert response.status_code == 404
     assert "detail" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_get_all_accounts_balances_after_transactions(
+    client: httpx.AsyncClient,
+) -> None:
+    """GET /api/accounts returns correct balances after two transactions."""
+    # Create accounts
+    cash_resp = await client.post(
+        "/api/accounts", json={"name": "Cash", "type": "ASSET"}
+    )
+    revenue_resp = await client.post(
+        "/api/accounts", json={"name": "Revenue", "type": "REVENUE"}
+    )
+    cash_id = cash_resp.json()["id"]
+    revenue_id = revenue_resp.json()["id"]
+
+    # Txn 1: debit Cash $500, credit Revenue $500
+    await client.post(
+        "/api/transactions",
+        json={
+            "timestamp": "2025-01-01T00:00:00Z",
+            "description": "Sale 1",
+            "entries": [
+                {"account_id": cash_id, "type": "DEBIT", "amount": "500.00"},
+                {"account_id": revenue_id, "type": "CREDIT", "amount": "500.00"},
+            ],
+        },
+    )
+    # Txn 2: debit Cash $300, credit Revenue $300
+    await client.post(
+        "/api/transactions",
+        json={
+            "timestamp": "2025-01-02T00:00:00Z",
+            "description": "Sale 2",
+            "entries": [
+                {"account_id": cash_id, "type": "DEBIT", "amount": "300.00"},
+                {"account_id": revenue_id, "type": "CREDIT", "amount": "300.00"},
+            ],
+        },
+    )
+
+    response = await client.get("/api/accounts")
+
+    assert response.status_code == 200
+    accounts = {a["name"]: a for a in response.json()}
+    assert accounts["Cash"]["balance"] == "800.00"
+    assert accounts["Revenue"]["balance"] == "800.00"
+
+
+@pytest.mark.asyncio
+async def test_get_account_by_id_balance_after_transaction(
+    client: httpx.AsyncClient,
+) -> None:
+    """GET /api/accounts/{id} returns correct balance after a transaction."""
+    cash_resp = await client.post(
+        "/api/accounts", json={"name": "Cash", "type": "ASSET"}
+    )
+    revenue_resp = await client.post(
+        "/api/accounts", json={"name": "Revenue", "type": "REVENUE"}
+    )
+    cash_id = cash_resp.json()["id"]
+    revenue_id = revenue_resp.json()["id"]
+
+    await client.post(
+        "/api/transactions",
+        json={
+            "timestamp": "2025-01-01T00:00:00Z",
+            "description": "Sale",
+            "entries": [
+                {"account_id": cash_id, "type": "DEBIT", "amount": "750.00"},
+                {"account_id": revenue_id, "type": "CREDIT", "amount": "750.00"},
+            ],
+        },
+    )
+
+    response = await client.get(f"/api/accounts/{cash_id}")
+
+    assert response.status_code == 200
+    assert response.json()["balance"] == "750.00"

--- a/tests/integration/test_balance_integration.py
+++ b/tests/integration/test_balance_integration.py
@@ -1,0 +1,262 @@
+"""Integration tests for SQL-based balance computation in AccountRepository."""
+
+import datetime
+import decimal
+import uuid
+
+import pytest
+import sqlalchemy.ext.asyncio as sa_async
+
+import ledger.domain.enums as enums
+import ledger.domain.models as models
+import ledger.infrastructure.mappers as mappers
+import ledger.infrastructure.models as orm_models
+import ledger.infrastructure.repositories.account_repo as account_repo_mod
+
+
+async def _create_account(
+    session: sa_async.AsyncSession,
+    name: str,
+    account_type: enums.AccountType,
+) -> models.Account:
+    """
+    Persist a domain account via ORM and return it.
+
+    :param session: async database session
+    :param name: account display name
+    :param account_type: financial classification
+    :return: persisted domain account
+    """
+    account = models.Account(id=uuid.uuid4(), name=name, type=account_type)
+    session.add(mappers.account_to_orm(account))
+    await session.flush()
+    return account
+
+
+async def _create_transaction(
+    session: sa_async.AsyncSession,
+    entries: list[tuple[uuid.UUID, enums.EntryType, str]],
+    description: str = "txn",
+) -> None:
+    """
+    Persist a transaction with entries via ORM.
+
+    :param session: async database session
+    :param entries: list of (account_id, entry_type, amount_str) tuples
+    :param description: transaction description
+    """
+    txn_id = uuid.uuid4()
+    orm_txn = orm_models.TransactionModel(
+        id=txn_id,
+        timestamp=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),
+        description=description,
+    )
+    session.add(orm_txn)
+    await session.flush()
+
+    for account_id, entry_type, amount_str in entries:
+        session.add(
+            orm_models.TransactionEntryModel(
+                id=uuid.uuid4(),
+                transaction_id=txn_id,
+                account_id=account_id,
+                entry_type=entry_type.value,
+                amount=decimal.Decimal(amount_str),
+            )
+        )
+    await session.flush()
+
+
+@pytest.mark.asyncio
+async def test_new_account_has_zero_balance(
+    db_session: sa_async.AsyncSession,
+) -> None:
+    """get_with_balance returns Decimal('0') for an account with no entries."""
+    repo = account_repo_mod.SqlaAccountRepository(db_session)
+    account = await _create_account(db_session, "Empty", enums.AccountType.ASSET)
+
+    result = await repo.get_with_balance(account.id)
+
+    assert result is not None
+    returned_account, balance = result
+    assert returned_account.id == account.id
+    assert balance == decimal.Decimal("0")
+
+
+class TestAssetBalance:
+    """Balance computation for ASSET accounts (debit-normal)."""
+
+    @pytest.mark.asyncio
+    async def test_debit_increases(self, db_session: sa_async.AsyncSession) -> None:
+        """ASSET + DEBIT entry produces a positive balance."""
+        repo = account_repo_mod.SqlaAccountRepository(db_session)
+        cash = await _create_account(db_session, "Cash", enums.AccountType.ASSET)
+        revenue = await _create_account(
+            db_session, "Revenue", enums.AccountType.REVENUE
+        )
+
+        await _create_transaction(
+            db_session,
+            [
+                (cash.id, enums.EntryType.DEBIT, "250.00"),
+                (revenue.id, enums.EntryType.CREDIT, "250.00"),
+            ],
+        )
+
+        result = await repo.get_with_balance(cash.id)
+        assert result is not None
+        _, balance = result
+        assert balance == decimal.Decimal("250.00")
+
+    @pytest.mark.asyncio
+    async def test_credit_decreases(self, db_session: sa_async.AsyncSession) -> None:
+        """ASSET + DEBIT then CREDIT yields the net balance."""
+        repo = account_repo_mod.SqlaAccountRepository(db_session)
+        cash = await _create_account(db_session, "Cash", enums.AccountType.ASSET)
+        revenue = await _create_account(
+            db_session, "Revenue", enums.AccountType.REVENUE
+        )
+
+        await _create_transaction(
+            db_session,
+            [
+                (cash.id, enums.EntryType.DEBIT, "500.00"),
+                (revenue.id, enums.EntryType.CREDIT, "500.00"),
+            ],
+        )
+        await _create_transaction(
+            db_session,
+            [
+                (revenue.id, enums.EntryType.DEBIT, "150.00"),
+                (cash.id, enums.EntryType.CREDIT, "150.00"),
+            ],
+        )
+
+        result = await repo.get_with_balance(cash.id)
+        assert result is not None
+        _, balance = result
+        assert balance == decimal.Decimal("350.00")
+
+
+class TestLiabilityBalance:
+    """Balance computation for LIABILITY accounts (credit-normal)."""
+
+    @pytest.mark.asyncio
+    async def test_credit_increases(self, db_session: sa_async.AsyncSession) -> None:
+        """LIABILITY + CREDIT entry produces a positive balance."""
+        repo = account_repo_mod.SqlaAccountRepository(db_session)
+        loan = await _create_account(db_session, "Loan", enums.AccountType.LIABILITY)
+        cash = await _create_account(db_session, "Cash", enums.AccountType.ASSET)
+
+        await _create_transaction(
+            db_session,
+            [
+                (cash.id, enums.EntryType.DEBIT, "1000.00"),
+                (loan.id, enums.EntryType.CREDIT, "1000.00"),
+            ],
+        )
+
+        result = await repo.get_with_balance(loan.id)
+        assert result is not None
+        _, balance = result
+        assert balance == decimal.Decimal("1000.00")
+
+    @pytest.mark.asyncio
+    async def test_debit_decreases(self, db_session: sa_async.AsyncSession) -> None:
+        """LIABILITY + CREDIT then DEBIT yields the net balance."""
+        repo = account_repo_mod.SqlaAccountRepository(db_session)
+        loan = await _create_account(db_session, "Loan", enums.AccountType.LIABILITY)
+        cash = await _create_account(db_session, "Cash", enums.AccountType.ASSET)
+
+        await _create_transaction(
+            db_session,
+            [
+                (cash.id, enums.EntryType.DEBIT, "1000.00"),
+                (loan.id, enums.EntryType.CREDIT, "1000.00"),
+            ],
+        )
+        await _create_transaction(
+            db_session,
+            [
+                (loan.id, enums.EntryType.DEBIT, "300.00"),
+                (cash.id, enums.EntryType.CREDIT, "300.00"),
+            ],
+        )
+
+        result = await repo.get_with_balance(loan.id)
+        assert result is not None
+        _, balance = result
+        assert balance == decimal.Decimal("700.00")
+
+
+class TestExpenseBalance:
+    """Balance computation for EXPENSE accounts (debit-normal)."""
+
+    @pytest.mark.asyncio
+    async def test_debit_increases(self, db_session: sa_async.AsyncSession) -> None:
+        """EXPENSE + DEBIT entry produces a positive balance."""
+        repo = account_repo_mod.SqlaAccountRepository(db_session)
+        rent = await _create_account(db_session, "Rent", enums.AccountType.EXPENSE)
+        cash = await _create_account(db_session, "Cash", enums.AccountType.ASSET)
+
+        await _create_transaction(
+            db_session,
+            [
+                (rent.id, enums.EntryType.DEBIT, "800.00"),
+                (cash.id, enums.EntryType.CREDIT, "800.00"),
+            ],
+        )
+
+        result = await repo.get_with_balance(rent.id)
+        assert result is not None
+        _, balance = result
+        assert balance == decimal.Decimal("800.00")
+
+
+@pytest.mark.asyncio
+async def test_cumulative_multiple_transactions(
+    db_session: sa_async.AsyncSession,
+) -> None:
+    """Multiple transactions on one account accumulate; get_all_with_balances works."""
+    repo = account_repo_mod.SqlaAccountRepository(db_session)
+    cash = await _create_account(db_session, "Cash", enums.AccountType.ASSET)
+    revenue = await _create_account(db_session, "Revenue", enums.AccountType.REVENUE)
+    expense = await _create_account(db_session, "Supplies", enums.AccountType.EXPENSE)
+
+    # Txn 1: receive $500 revenue
+    await _create_transaction(
+        db_session,
+        [
+            (cash.id, enums.EntryType.DEBIT, "500.00"),
+            (revenue.id, enums.EntryType.CREDIT, "500.00"),
+        ],
+    )
+    # Txn 2: receive $300 revenue
+    await _create_transaction(
+        db_session,
+        [
+            (cash.id, enums.EntryType.DEBIT, "300.00"),
+            (revenue.id, enums.EntryType.CREDIT, "300.00"),
+        ],
+    )
+    # Txn 3: pay $200 for supplies
+    await _create_transaction(
+        db_session,
+        [
+            (expense.id, enums.EntryType.DEBIT, "200.00"),
+            (cash.id, enums.EntryType.CREDIT, "200.00"),
+        ],
+    )
+
+    # Verify single account
+    result = await repo.get_with_balance(cash.id)
+    assert result is not None
+    _, cash_balance = result
+    assert cash_balance == decimal.Decimal("600.00")
+
+    # Verify get_all_with_balances
+    all_results = await repo.get_all_with_balances()
+    balances = {account.name: balance for account, balance in all_results}
+    assert balances["Cash"] == decimal.Decimal("600.00")
+    assert balances["Revenue"] == decimal.Decimal("800.00")
+    assert balances["Supplies"] == decimal.Decimal("200.00")


### PR DESCRIPTION
## Summary
- Add `get_with_balance()` and `get_all_with_balances()` to `AccountRepository` protocol with SQL aggregation (`SUM(CASE WHEN)` + `LEFT JOIN`) per ADR-002
- Remove `TransactionRepository` dependency from `AccountService`, eliminating N+1 query pattern
- Simplify `dependencies.py` — `get_account_service()` now only needs `account_repository`

## Test plan
- [x] 7 integration tests for SQL balance computation (`test_balance_integration.py`)
- [x] 2 new API tests for balance after transactions (`test_accounts_api.py`)
- [x] All 99 tests pass
- [x] ruff check, ruff format, mypy — all clean

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)