### PR TITLE
docs: update docs for SQL balance calculation

### DIFF
--- a/docs/adr/002-balance-computation.md
+++ b/docs/adr/002-balance-computation.md
@@ -50,30 +50,36 @@ We use **SQL aggregation** for balance computation at the repository layer, with
 
 ## Implementation
 
-The SQL query pattern:
+The SQL query pattern (column names match the ORM: `account_type`, `entry_type`):
 
 ```sql
 SELECT
     a.id,
     a.name,
-    a.type,
+    a.account_type,
     COALESCE(
         CASE
-            WHEN a.type IN ('ASSET', 'EXPENSE')
-            THEN SUM(CASE WHEN te.type = 'DEBIT' THEN te.amount ELSE 0 END)
-               - SUM(CASE WHEN te.type = 'CREDIT' THEN te.amount ELSE 0 END)
+            WHEN a.account_type IN ('ASSET', 'EXPENSE')
+            THEN SUM(CASE WHEN te.entry_type = 'DEBIT' THEN te.amount ELSE 0 END)
+               - SUM(CASE WHEN te.entry_type = 'CREDIT' THEN te.amount ELSE 0 END)
             ELSE
-                 SUM(CASE WHEN te.type = 'CREDIT' THEN te.amount ELSE 0 END)
-               - SUM(CASE WHEN te.type = 'DEBIT' THEN te.amount ELSE 0 END)
+                 SUM(CASE WHEN te.entry_type = 'CREDIT' THEN te.amount ELSE 0 END)
+               - SUM(CASE WHEN te.entry_type = 'DEBIT' THEN te.amount ELSE 0 END)
         END,
         0
     ) AS balance
 FROM accounts a
 LEFT JOIN transaction_entries te ON te.account_id = a.id
-GROUP BY a.id, a.name, a.type;
+GROUP BY a.id, a.name, a.account_type;
 ```
 
 The `LEFT JOIN` ensures accounts with no entries return a balance of `0`. The `COALESCE` handles NULL from empty aggregations.
+
+This is implemented in `SqlaAccountRepository` via two methods:
+- `get_with_balance(account_id)` -- single account with balance
+- `get_all_with_balances()` -- all accounts with balances in one query
+
+`AccountService` depends **only** on `AccountRepository` (not `TransactionRepository`), delegating all balance computation to the repository layer.
 
 ## Consequences
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,8 +79,8 @@ Orchestrates use cases by combining domain logic with repository calls.
 
 | Module | Purpose |
 |---|---|
-| `interfaces.py` | Repository protocols (`AccountRepository`, `TransactionRepository`) using `typing.Protocol` |
-| `account_service.py` | `AccountService`: create account, get account with balance, list accounts. Returns `AccountWithBalance` DTO. |
+| `interfaces.py` | Repository protocols (`AccountRepository`, `TransactionRepository`) using `typing.Protocol`. `AccountRepository` includes `get_with_balance()` and `get_all_with_balances()` for SQL-aggregated balance retrieval. |
+| `account_service.py` | `AccountService`: create account, get account with balance, list accounts. Returns `AccountWithBalance` DTO. Depends only on `AccountRepository` (balance is computed at the repository layer via SQL aggregation). |
 | `transaction_service.py` | `TransactionService`: create transaction (validate accounts + entries, persist), get by ID, get by account. Uses `EntryData` DTO. |
 
 **Rules:**

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -144,7 +144,9 @@ graph LR
 
 ### Implementation Choice
 
-Balance is computed via **SQL aggregation** (SUM with CASE WHEN) rather than loading all entries into Python. This gives O(1) memory usage regardless of entry count.
+Balance is computed via **SQL aggregation** (SUM with CASE WHEN) rather than loading all entries into Python. This gives O(1) memory usage regardless of entry count. The aggregation is implemented in `AccountRepository.get_with_balance()` and `AccountRepository.get_all_with_balances()`, so `AccountService` does not depend on `TransactionRepository` for balance computation.
+
+The domain layer's pure Python `calculate_balance()` function is preserved for unit testing.
 
 See [ADR-002: Balance Computation](./adr/002-balance-computation.md) for the decision rationale.
 


### PR DESCRIPTION
## Summary
- **ADR-002**: Fix SQL column names (`account_type`, `entry_type` instead of `type`), add note about `get_with_balance()`/`get_all_with_balances()` methods and `AccountService` dependency simplification
- **architecture.md**: Update `interfaces.py` and `account_service.py` descriptions to reflect new repo methods and removed `TransactionRepository` dependency
- **domain-model.md**: Clarify that SQL aggregation lives in `AccountRepository` methods, and domain `calculate_balance()` is preserved for unit tests

Follow-up to #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)