### PR TITLE
feat: pagination, date filtering, and OpenAPI descriptions

### DIFF
--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -109,20 +109,30 @@ curl -X POST http://localhost:8000/api/accounts \
 
 ### GET /api/accounts
 
-List all accounts with their computed balances.
+List all accounts with their computed balances. Supports optional pagination. Results are ordered by account name ascending.
 
-**Request:** No body. No query parameters (pagination in bonus phase).
+**Query Parameters:**
+
+| Parameter | Type | Default | Constraints | Description |
+|---|---|---|---|---|
+| `limit` | integer | *(none — return all)* | 1–100 | Maximum number of accounts to return |
+| `offset` | integer | `0` | >= 0 | Number of accounts to skip |
 
 **Response:**
 
 | Status | Body | When |
 |---|---|---|
 | `200 OK` | Array of account responses | Always (empty array if none) |
+| `422 Unprocessable Entity` | Validation errors | Invalid query parameter values |
 
-**Example:**
+**Examples:**
 
 ```bash
+# All accounts
 curl http://localhost:8000/api/accounts
+
+# Paginated
+curl "http://localhost:8000/api/accounts?limit=2&offset=0"
 ```
 
 ```json
@@ -131,15 +141,13 @@ curl http://localhost:8000/api/accounts
     "id": "uuid-1",
     "name": "Cash",
     "type": "ASSET",
-    "balance": "1350.00",
-    "createdAt": "2024-01-15T10:00:00"
+    "balance": "1350.00"
   },
   {
     "id": "uuid-2",
     "name": "Revenue",
     "type": "REVENUE",
-    "balance": "500.00",
-    "createdAt": "2024-01-15T10:00:00"
+    "balance": "500.00"
   }
 ]
 ```
@@ -269,7 +277,7 @@ curl http://localhost:8000/api/transactions/7c9e6679-7425-40de-944b-e07fc1f90ae7
 
 ### GET /api/accounts/{id}/transactions
 
-Get all transactions that affect a given account (i.e., have at least one entry referencing the account).
+Get transactions that affect a given account (i.e., have at least one entry referencing the account). Supports pagination and date filtering. Results are ordered by timestamp ascending.
 
 **Path Parameters:**
 
@@ -277,17 +285,31 @@ Get all transactions that affect a given account (i.e., have at least one entry 
 |---|---|---|
 | `id` | UUID | Account ID |
 
+**Query Parameters:**
+
+| Parameter | Type | Default | Constraints | Description |
+|---|---|---|---|---|
+| `limit` | integer | *(none — return all)* | 1–100 | Maximum number of transactions to return |
+| `offset` | integer | `0` | >= 0 | Number of transactions to skip |
+| `from_date` | datetime | *(none)* | ISO 8601 | Inclusive lower bound on transaction timestamp |
+| `to_date` | datetime | *(none)* | ISO 8601 | Inclusive upper bound on transaction timestamp |
+
 **Response:**
 
 | Status | Body | When |
 |---|---|---|
 | `200 OK` | Array of transaction responses | Account exists (empty array if no transactions) |
 | `404 Not Found` | Error detail | Account does not exist |
+| `422 Unprocessable Entity` | Validation errors | Invalid query parameter values |
 
-**Example:**
+**Examples:**
 
 ```bash
+# All transactions for account
 curl http://localhost:8000/api/accounts/550e8400-e29b-41d4-a716-446655440000/transactions
+
+# Paginated with date filtering
+curl "http://localhost:8000/api/accounts/550e8400-e29b-41d4-a716-446655440000/transactions?from_date=2025-01-01T00:00:00&to_date=2025-12-31T23:59:59&limit=10"
 ```
 
 ---

--- a/src/ledger/api/routers/accounts.py
+++ b/src/ledger/api/routers/accounts.py
@@ -33,6 +33,10 @@ def _to_response(
     "",
     response_model=schemas.AccountResponse,
     status_code=201,
+    summary="Create account",
+    description="Create a new financial account with the given name and type. "
+    "The name must be unique and non-empty. Balance starts at 0.00.",
+    response_description="The created account with a zero balance.",
 )
 async def create_account(
     body: schemas.CreateAccountRequest,
@@ -55,26 +59,46 @@ async def create_account(
 @router.get(
     "",
     response_model=list[schemas.AccountResponse],
+    summary="List accounts",
+    description="Retrieve all accounts with their balances computed via "
+    "SQL aggregation. Supports optional pagination via limit and offset.",
+    response_description="Array of accounts with computed balances.",
 )
 async def list_accounts(
     service: typing.Annotated[
         account_service.AccountService,
         fastapi.Depends(dependencies.get_account_service),
     ],
+    limit: typing.Annotated[
+        int | None,
+        fastapi.Query(
+            ge=1, le=100, description="Maximum number of accounts to return."
+        ),
+    ] = None,
+    offset: typing.Annotated[
+        int,
+        fastapi.Query(ge=0, description="Number of accounts to skip."),
+    ] = 0,
 ) -> list[schemas.AccountResponse]:
     """
     List all accounts with computed balances.
 
     :param service: injected account service
+    :param limit: maximum number of accounts to return (None = all)
+    :param offset: number of accounts to skip
     :return: list of accounts with balances
     """
-    results = await service.get_all()
+    results = await service.get_all(limit=limit, offset=offset)
     return [_to_response(r) for r in results]
 
 
 @router.get(
     "/{account_id}",
     response_model=schemas.AccountResponse,
+    summary="Get account",
+    description="Retrieve a single account by its UUID, including the balance "
+    "computed via SQL aggregation across all transaction entries.",
+    response_description="The account with its computed balance.",
 )
 async def get_account(
     account_id: uuid.UUID,

--- a/src/ledger/api/routers/transactions.py
+++ b/src/ledger/api/routers/transactions.py
@@ -1,5 +1,6 @@
 """Transaction API route handlers: create, get by ID, and get by account."""
 
+import datetime
 import typing
 import uuid
 
@@ -56,6 +57,11 @@ def _txn_to_response(
     response_model=schemas.TransactionResponse,
     status_code=201,
     response_model_by_alias=True,
+    summary="Create transaction",
+    description="Create a new double-entry transaction. Requires at least two entries "
+    "(one DEBIT and one CREDIT) whose amounts balance exactly. All referenced "
+    "accounts must exist.",
+    response_description="The created transaction with all entries.",
 )
 async def create_transaction(
     body: schemas.CreateTransactionRequest,
@@ -91,6 +97,10 @@ async def create_transaction(
     "/{transaction_id}",
     response_model=schemas.TransactionResponse,
     response_model_by_alias=True,
+    summary="Get transaction",
+    description="Retrieve a single transaction by its UUID, including all "
+    "debit and credit entries.",
+    response_description="The transaction with all entries.",
 )
 async def get_transaction(
     transaction_id: uuid.UUID,
@@ -114,6 +124,11 @@ async def get_transaction(
     "/{account_id}/transactions",
     response_model=list[schemas.TransactionResponse],
     response_model_by_alias=True,
+    summary="List account transactions",
+    description="Retrieve transactions affecting a given account. Supports "
+    "pagination via limit/offset and date filtering via from_date/to_date "
+    "(inclusive). Results are ordered by timestamp ascending.",
+    response_description="Array of transactions with all entries.",
 )
 async def get_account_transactions(
     account_id: uuid.UUID,
@@ -121,13 +136,45 @@ async def get_account_transactions(
         transaction_service.TransactionService,
         fastapi.Depends(dependencies.get_transaction_service),
     ],
+    limit: typing.Annotated[
+        int | None,
+        fastapi.Query(
+            ge=1, le=100, description="Maximum number of transactions to return."
+        ),
+    ] = None,
+    offset: typing.Annotated[
+        int,
+        fastapi.Query(ge=0, description="Number of transactions to skip."),
+    ] = 0,
+    from_date: typing.Annotated[
+        datetime.datetime | None,
+        fastapi.Query(
+            description="Inclusive lower bound on transaction timestamp (ISO 8601)."
+        ),
+    ] = None,
+    to_date: typing.Annotated[
+        datetime.datetime | None,
+        fastapi.Query(
+            description="Inclusive upper bound on transaction timestamp (ISO 8601)."
+        ),
+    ] = None,
 ) -> list[schemas.TransactionResponse]:
     """
-    Retrieve all transactions affecting a given account.
+    Retrieve transactions affecting a given account.
 
     :param account_id: UUID path parameter for the account
     :param service: injected transaction service
+    :param limit: maximum number of transactions to return (None = all)
+    :param offset: number of transactions to skip
+    :param from_date: inclusive lower bound on transaction timestamp
+    :param to_date: inclusive upper bound on transaction timestamp
     :return: list of transactions with entries
     """
-    results = await service.get_by_account_id(account_id)
+    results = await service.get_by_account_id(
+        account_id,
+        limit=limit,
+        offset=offset,
+        from_date=from_date,
+        to_date=to_date,
+    )
     return [_txn_to_response(r) for r in results]

--- a/src/ledger/api/schemas.py
+++ b/src/ledger/api/schemas.py
@@ -11,17 +11,24 @@ import ledger.domain.enums as enums
 class CreateAccountRequest(pydantic.BaseModel):
     """Request body for creating a new account."""
 
-    name: str
-    type: enums.AccountType
+    name: str = pydantic.Field(description="Unique display name for the account.")
+    type: enums.AccountType = pydantic.Field(
+        description="Financial classification: ASSET, LIABILITY, REVENUE, or EXPENSE."
+    )
 
 
 class AccountResponse(pydantic.BaseModel):
     """Response body representing an account with its computed balance."""
 
-    id: str
-    name: str
-    type: enums.AccountType
-    balance: str
+    id: str = pydantic.Field(description="Unique account identifier (UUID).")
+    name: str = pydantic.Field(description="Account display name.")
+    type: enums.AccountType = pydantic.Field(
+        description="Financial classification: ASSET, LIABILITY, REVENUE, or EXPENSE."
+    )
+    balance: str = pydantic.Field(
+        description="Current balance computed from all transaction "
+        "entries (e.g. '1350.00')."
+    )
 
 
 class TransactionEntryRequest(pydantic.BaseModel):
@@ -29,9 +36,14 @@ class TransactionEntryRequest(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(populate_by_name=True)
 
-    account_id: str = pydantic.Field(alias="accountId")
-    type: enums.EntryType
-    amount: decimal.Decimal
+    account_id: str = pydantic.Field(
+        alias="accountId",
+        description="UUID of the account this entry affects.",
+    )
+    type: enums.EntryType = pydantic.Field(description="Entry type: DEBIT or CREDIT.")
+    amount: decimal.Decimal = pydantic.Field(
+        description="Positive monetary amount (e.g. 100.00)."
+    )
 
 
 class CreateTransactionRequest(pydantic.BaseModel):
@@ -39,9 +51,16 @@ class CreateTransactionRequest(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(populate_by_name=True)
 
-    description: str
-    timestamp: datetime.datetime = pydantic.Field(alias="date")
-    entries: list[TransactionEntryRequest]
+    description: str = pydantic.Field(
+        description="Human-readable description of the transaction."
+    )
+    timestamp: datetime.datetime = pydantic.Field(
+        alias="date",
+        description="When the transaction occurred (ISO 8601).",
+    )
+    entries: list[TransactionEntryRequest] = pydantic.Field(
+        description="Debit and credit entries (minimum 2, must balance)."
+    )
 
 
 class TransactionEntryResponse(pydantic.BaseModel):
@@ -49,16 +68,27 @@ class TransactionEntryResponse(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(populate_by_name=True)
 
-    id: str
-    account_id: str = pydantic.Field(alias="accountId")
-    type: enums.EntryType
-    amount: str
+    id: str = pydantic.Field(description="Unique entry identifier (UUID).")
+    account_id: str = pydantic.Field(
+        alias="accountId",
+        description="UUID of the account this entry affects.",
+    )
+    type: enums.EntryType = pydantic.Field(description="Entry type: DEBIT or CREDIT.")
+    amount: str = pydantic.Field(
+        description="Monetary amount as a string with 2 decimal places."
+    )
 
 
 class TransactionResponse(pydantic.BaseModel):
     """Response body representing a transaction with its entries."""
 
-    id: str
-    description: str
-    timestamp: str
-    entries: list[TransactionEntryResponse]
+    id: str = pydantic.Field(description="Unique transaction identifier (UUID).")
+    description: str = pydantic.Field(
+        description="Human-readable description of the transaction."
+    )
+    timestamp: str = pydantic.Field(
+        description="When the transaction occurred (ISO 8601)."
+    )
+    entries: list[TransactionEntryResponse] = pydantic.Field(
+        description="All debit and credit entries for this transaction."
+    )

--- a/src/ledger/application/account_service.py
+++ b/src/ledger/application/account_service.py
@@ -75,13 +75,21 @@ class AccountService:
         account, balance = result
         return AccountWithBalance(account=account, balance=balance)
 
-    async def get_all(self) -> list[AccountWithBalance]:
+    async def get_all(
+        self,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[AccountWithBalance]:
         """
         Retrieve all accounts with balances computed via SQL aggregation.
 
+        :param limit: maximum number of accounts to return (None = all)
+        :param offset: number of accounts to skip
         :return: list of accounts with their balances
         """
-        results = await self._account_repo.get_all_with_balances()
+        results = await self._account_repo.get_all_with_balances(
+            limit=limit, offset=offset
+        )
         return [
             AccountWithBalance(account=account, balance=balance)
             for account, balance in results

--- a/src/ledger/application/interfaces.py
+++ b/src/ledger/application/interfaces.py
@@ -1,5 +1,6 @@
 """Repository interfaces defining data-access contracts for the application layer."""
 
+import datetime
 import decimal
 import typing
 import uuid
@@ -59,10 +60,14 @@ class AccountRepository(typing.Protocol):
 
     async def get_all_with_balances(
         self,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[tuple[models.Account, decimal.Decimal]]:
         """
         Retrieve all accounts with their computed balances via SQL aggregation.
 
+        :param limit: maximum number of accounts to return (None = all)
+        :param offset: number of accounts to skip
         :return: list of (account, balance) tuples
         """
         ...
@@ -90,15 +95,24 @@ class TransactionRepository(typing.Protocol):
         ...
 
     async def get_by_account_id(
-        self, account_id: uuid.UUID
+        self,
+        account_id: uuid.UUID,
+        limit: int | None = None,
+        offset: int = 0,
+        from_date: datetime.datetime | None = None,
+        to_date: datetime.datetime | None = None,
     ) -> list[models.Transaction]:
         """
-        Retrieve all transactions that have at least one entry for the given account.
+        Retrieve transactions that have at least one entry for the given account.
 
         Returns full transactions with ALL entries (not just the matching
         account's), preserving the double-entry invariant.
 
         :param account_id: UUID of the account
+        :param limit: maximum number of transactions to return (None = all)
+        :param offset: number of transactions to skip
+        :param from_date: inclusive lower bound on transaction timestamp
+        :param to_date: inclusive upper bound on transaction timestamp
         :return: list of transactions involving the account
         """
         ...

--- a/src/ledger/application/transaction_service.py
+++ b/src/ledger/application/transaction_service.py
@@ -104,16 +104,31 @@ class TransactionService:
         return txn
 
     async def get_by_account_id(
-        self, account_id: uuid.UUID
+        self,
+        account_id: uuid.UUID,
+        limit: int | None = None,
+        offset: int = 0,
+        from_date: datetime.datetime | None = None,
+        to_date: datetime.datetime | None = None,
     ) -> list[models.Transaction]:
         """
-        Retrieve all transactions involving a given account.
+        Retrieve transactions involving a given account with optional filtering.
 
         :param account_id: UUID of the account
+        :param limit: maximum number of transactions to return (None = all)
+        :param offset: number of transactions to skip
+        :param from_date: inclusive lower bound on transaction timestamp
+        :param to_date: inclusive upper bound on transaction timestamp
         :return: list of transactions with entries
         :raises AccountNotFoundError: if the account does not exist
         """
         account = await self._account_repo.get_by_id(account_id)
         if account is None:
             raise exceptions.AccountNotFoundError(f"Account {account_id} not found")
-        return await self._transaction_repo.get_by_account_id(account_id)
+        return await self._transaction_repo.get_by_account_id(
+            account_id,
+            limit=limit,
+            offset=offset,
+            from_date=from_date,
+            to_date=to_date,
+        )

--- a/src/ledger/infrastructure/repositories/account_repo.py
+++ b/src/ledger/infrastructure/repositories/account_repo.py
@@ -120,10 +120,14 @@ class SqlaAccountRepository:
 
     async def get_all_with_balances(
         self,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[tuple[models.Account, decimal.Decimal]]:
         """
         Retrieve all accounts with their computed balances via SQL aggregation.
 
+        :param limit: maximum number of accounts to return (None = all)
+        :param offset: number of accounts to skip
         :return: list of (account, balance) tuples
         """
         stmt = (
@@ -143,7 +147,11 @@ class SqlaAccountRepository:
                 orm_models.AccountModel.name,
                 orm_models.AccountModel.account_type,
             )
+            .order_by(orm_models.AccountModel.name)
+            .offset(offset)
         )
+        if limit is not None:
+            stmt = stmt.limit(limit)
         result = await self._session.execute(stmt)
         return [
             (

--- a/src/ledger/infrastructure/repositories/transaction_repo.py
+++ b/src/ledger/infrastructure/repositories/transaction_repo.py
@@ -1,5 +1,6 @@
 """SQLAlchemy-based transaction repository implementation."""
 
+import datetime
 import uuid
 
 import sqlalchemy as sa
@@ -49,23 +50,42 @@ class SqlaTransactionRepository:
             return mappers.transaction_to_domain(row)
 
     async def get_by_account_id(
-        self, account_id: uuid.UUID
+        self,
+        account_id: uuid.UUID,
+        limit: int | None = None,
+        offset: int = 0,
+        from_date: datetime.datetime | None = None,
+        to_date: datetime.datetime | None = None,
     ) -> list[models.Transaction]:
         """
-        Retrieve all transactions that have at least one entry for the given account.
+        Retrieve transactions that have at least one entry for the given account.
 
         Uses a join with DISTINCT to find matching transactions, then returns
         full transactions with ALL entries (preserving double-entry invariant).
 
         :param account_id: UUID of the account
+        :param limit: maximum number of transactions to return (None = all)
+        :param offset: number of transactions to skip
+        :param from_date: inclusive lower bound on transaction timestamp
+        :param to_date: inclusive upper bound on transaction timestamp
         :return: list of transactions involving the account
         """
         stmt = (
             sa.select(orm_models.TransactionModel)
             .join(orm_models.TransactionEntryModel)
             .where(orm_models.TransactionEntryModel.account_id == account_id)
-            .distinct()
         )
+        if from_date is not None:
+            stmt = stmt.where(orm_models.TransactionModel.timestamp >= from_date)
+        if to_date is not None:
+            stmt = stmt.where(orm_models.TransactionModel.timestamp <= to_date)
+        stmt = (
+            stmt.distinct()
+            .order_by(orm_models.TransactionModel.timestamp)
+            .offset(offset)
+        )
+        if limit is not None:
+            stmt = stmt.limit(limit)
         result = await self._session.execute(stmt)
         rows = result.scalars().all()
         return [mappers.transaction_to_domain(r) for r in rows]

--- a/src/ledger/main.py
+++ b/src/ledger/main.py
@@ -50,7 +50,12 @@ def create_app() -> fastapi.FastAPI:
     app.include_router(transactions_router.router)
     app.include_router(transactions_router.account_transactions_router)
 
-    @app.get("/health")
+    @app.get(
+        "/health",
+        summary="Health check",
+        description="Returns a simple status object indicating the service is running.",
+        response_description="Status object with 'ok' value.",
+    )
     async def health() -> dict[str, str]:
         """
         Health check endpoint.

--- a/tests/api/test_accounts_api.py
+++ b/tests/api/test_accounts_api.py
@@ -210,6 +210,44 @@ async def test_get_all_accounts_balances_after_transactions(
 
 
 @pytest.mark.asyncio
+async def test_list_accounts_with_limit(client: httpx.AsyncClient) -> None:
+    """GET /api/accounts?limit=2 returns at most 2 accounts."""
+    for name in ["Alpha", "Bravo", "Charlie"]:
+        await client.post("/api/accounts", json={"name": name, "type": "ASSET"})
+
+    response = await client.get("/api/accounts", params={"limit": 2})
+
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_accounts_with_offset(client: httpx.AsyncClient) -> None:
+    """GET /api/accounts?offset=1 skips the first account (ordered by name)."""
+    for name in ["Alpha", "Bravo", "Charlie"]:
+        await client.post("/api/accounts", json={"name": name, "type": "ASSET"})
+
+    response = await client.get("/api/accounts", params={"offset": 1})
+
+    assert response.status_code == 200
+    names = [a["name"] for a in response.json()]
+    assert "Alpha" not in names
+    assert len(names) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_accounts_no_limit_returns_all(client: httpx.AsyncClient) -> None:
+    """GET /api/accounts without limit returns all accounts."""
+    for name in ["Alpha", "Bravo", "Charlie"]:
+        await client.post("/api/accounts", json={"name": name, "type": "ASSET"})
+
+    response = await client.get("/api/accounts")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 3
+
+
+@pytest.mark.asyncio
 async def test_get_account_by_id_balance_after_transaction(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/api/test_transactions_api.py
+++ b/tests/api/test_transactions_api.py
@@ -306,3 +306,163 @@ async def test_get_transactions_for_nonexistent_account(
 
     assert response.status_code == 404
     assert "detail" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_get_account_transactions_with_limit(
+    client: httpx.AsyncClient,
+) -> None:
+    """GET /api/accounts/{id}/transactions?limit=1 returns at most 1 transaction."""
+    cash_id = await _create_account(client, "Cash", "ASSET")
+    revenue_id = await _create_account(client, "Revenue", "REVENUE")
+
+    for i in range(3):
+        await client.post(
+            "/api/transactions",
+            json={
+                "description": f"Sale {i + 1}",
+                "date": f"2025-01-0{i + 1}T10:00:00",
+                "entries": [
+                    {"accountId": cash_id, "type": "DEBIT", "amount": 100.00},
+                    {"accountId": revenue_id, "type": "CREDIT", "amount": 100.00},
+                ],
+            },
+        )
+
+    response = await client.get(
+        f"/api/accounts/{cash_id}/transactions", params={"limit": 1}
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_account_transactions_with_offset(
+    client: httpx.AsyncClient,
+) -> None:
+    """GET /api/accounts/{id}/transactions?offset=1 skips the first transaction."""
+    cash_id = await _create_account(client, "Cash", "ASSET")
+    revenue_id = await _create_account(client, "Revenue", "REVENUE")
+
+    for i in range(3):
+        await client.post(
+            "/api/transactions",
+            json={
+                "description": f"Sale {i + 1}",
+                "date": f"2025-01-0{i + 1}T10:00:00",
+                "entries": [
+                    {"accountId": cash_id, "type": "DEBIT", "amount": 100.00},
+                    {"accountId": revenue_id, "type": "CREDIT", "amount": 100.00},
+                ],
+            },
+        )
+
+    response = await client.get(
+        f"/api/accounts/{cash_id}/transactions", params={"offset": 1}
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_account_transactions_with_from_date(
+    client: httpx.AsyncClient,
+) -> None:
+    """from_date query param excludes earlier transactions."""
+    cash_id = await _create_account(client, "Cash", "ASSET")
+    revenue_id = await _create_account(client, "Revenue", "REVENUE")
+
+    for i in range(3):
+        await client.post(
+            "/api/transactions",
+            json={
+                "description": f"Sale {i + 1}",
+                "date": f"2025-01-0{i + 1}T10:00:00",
+                "entries": [
+                    {"accountId": cash_id, "type": "DEBIT", "amount": 100.00},
+                    {"accountId": revenue_id, "type": "CREDIT", "amount": 100.00},
+                ],
+            },
+        )
+
+    response = await client.get(
+        f"/api/accounts/{cash_id}/transactions",
+        params={"from_date": "2025-01-02T00:00:00"},
+    )
+
+    assert response.status_code == 200
+    txns = response.json()
+    assert len(txns) == 2
+    descriptions = {t["description"] for t in txns}
+    assert "Sale 1" not in descriptions
+
+
+@pytest.mark.asyncio
+async def test_get_account_transactions_with_to_date(
+    client: httpx.AsyncClient,
+) -> None:
+    """GET /api/accounts/{id}/transactions?to_date=... excludes later transactions."""
+    cash_id = await _create_account(client, "Cash", "ASSET")
+    revenue_id = await _create_account(client, "Revenue", "REVENUE")
+
+    for i in range(3):
+        await client.post(
+            "/api/transactions",
+            json={
+                "description": f"Sale {i + 1}",
+                "date": f"2025-01-0{i + 1}T10:00:00",
+                "entries": [
+                    {"accountId": cash_id, "type": "DEBIT", "amount": 100.00},
+                    {"accountId": revenue_id, "type": "CREDIT", "amount": 100.00},
+                ],
+            },
+        )
+
+    response = await client.get(
+        f"/api/accounts/{cash_id}/transactions",
+        params={"to_date": "2025-01-02T23:59:59"},
+    )
+
+    assert response.status_code == 200
+    txns = response.json()
+    assert len(txns) == 2
+    descriptions = {t["description"] for t in txns}
+    assert "Sale 3" not in descriptions
+
+
+@pytest.mark.asyncio
+async def test_get_account_transactions_with_date_range(
+    client: httpx.AsyncClient,
+) -> None:
+    """from_date + to_date returns only transactions in range."""
+    cash_id = await _create_account(client, "Cash", "ASSET")
+    revenue_id = await _create_account(client, "Revenue", "REVENUE")
+
+    for i in range(5):
+        await client.post(
+            "/api/transactions",
+            json={
+                "description": f"Sale {i + 1}",
+                "date": f"2025-01-0{i + 1}T10:00:00",
+                "entries": [
+                    {"accountId": cash_id, "type": "DEBIT", "amount": 100.00},
+                    {"accountId": revenue_id, "type": "CREDIT", "amount": 100.00},
+                ],
+            },
+        )
+
+    response = await client.get(
+        f"/api/accounts/{cash_id}/transactions",
+        params={
+            "from_date": "2025-01-02T00:00:00",
+            "to_date": "2025-01-04T23:59:59",
+        },
+    )
+
+    assert response.status_code == 200
+    txns = response.json()
+    assert len(txns) == 3
+    descriptions = {t["description"] for t in txns}
+    assert descriptions == {"Sale 2", "Sale 3", "Sale 4"}

--- a/tests/integration/test_account_repo.py
+++ b/tests/integration/test_account_repo.py
@@ -137,3 +137,49 @@ class TestAccountRepoExists:
         repo = account_repo_mod.SqlaAccountRepository(db_session)
 
         assert await repo.exists(uuid.uuid4()) is False
+
+
+class TestAccountRepoPagination:
+    """Tests for get_all_with_balances() pagination via limit and offset."""
+
+    async def test_limit_restricts_result_count(
+        self, db_session: sa_async.AsyncSession
+    ) -> None:
+        """get_all_with_balances with limit=2 returns at most 2 accounts."""
+        repo = account_repo_mod.SqlaAccountRepository(db_session)
+        for name in ["Alpha", "Bravo", "Charlie"]:
+            await repo.create(
+                models.Account(id=uuid.uuid4(), name=name, type=enums.AccountType.ASSET)
+            )
+
+        result = await repo.get_all_with_balances(limit=2)
+
+        assert len(result) == 2
+
+    async def test_offset_skips_rows(self, db_session: sa_async.AsyncSession) -> None:
+        """offset=1 skips first account (ordered by name)."""
+        repo = account_repo_mod.SqlaAccountRepository(db_session)
+        for name in ["Alpha", "Bravo", "Charlie"]:
+            await repo.create(
+                models.Account(id=uuid.uuid4(), name=name, type=enums.AccountType.ASSET)
+            )
+
+        result = await repo.get_all_with_balances(offset=1)
+
+        names = [account.name for account, _ in result]
+        assert "Alpha" not in names
+        assert len(names) == 2
+
+    async def test_no_limit_returns_all(
+        self, db_session: sa_async.AsyncSession
+    ) -> None:
+        """get_all_with_balances without limit returns all accounts."""
+        repo = account_repo_mod.SqlaAccountRepository(db_session)
+        for name in ["Alpha", "Bravo", "Charlie"]:
+            await repo.create(
+                models.Account(id=uuid.uuid4(), name=name, type=enums.AccountType.ASSET)
+            )
+
+        result = await repo.get_all_with_balances()
+
+        assert len(result) == 3

--- a/tests/integration/test_transaction_repo.py
+++ b/tests/integration/test_transaction_repo.py
@@ -33,6 +33,45 @@ async def two_accounts(
     return cash, revenue
 
 
+def _make_transaction_with_timestamp(
+    cash_id: uuid.UUID,
+    revenue_id: uuid.UUID,
+    timestamp: datetime.datetime,
+    description: str = "Sale",
+) -> models.Transaction:
+    """
+    Build a balanced domain transaction with a specific timestamp.
+
+    :param cash_id: UUID of the debit account
+    :param revenue_id: UUID of the credit account
+    :param timestamp: when the transaction occurred
+    :param description: human-readable description
+    :return: domain transaction with two entries
+    """
+    txn_id = uuid.uuid4()
+    return models.Transaction(
+        id=txn_id,
+        timestamp=timestamp,
+        description=description,
+        entries=[
+            models.TransactionEntry(
+                id=uuid.uuid4(),
+                transaction_id=txn_id,
+                account_id=cash_id,
+                type=enums.EntryType.DEBIT,
+                amount=decimal.Decimal("100.00"),
+            ),
+            models.TransactionEntry(
+                id=uuid.uuid4(),
+                transaction_id=txn_id,
+                account_id=revenue_id,
+                type=enums.EntryType.CREDIT,
+                amount=decimal.Decimal("100.00"),
+            ),
+        ],
+    )
+
+
 def _make_transaction(cash_id: uuid.UUID, revenue_id: uuid.UUID) -> models.Transaction:
     """
     Build a balanced domain transaction between two accounts.
@@ -181,3 +220,149 @@ class TestTransactionRepoGetByAccountId:
         result = await repo.get_by_account_id(uuid.uuid4())
 
         assert result == []
+
+
+class TestTransactionRepoPaginationAndFiltering:
+    """Tests for get_by_account_id() pagination and date filtering."""
+
+    async def test_limit_restricts_result_count(
+        self,
+        db_session: sa_async.AsyncSession,
+        two_accounts: tuple[models.Account, models.Account],
+    ) -> None:
+        """get_by_account_id with limit=1 returns at most 1 transaction."""
+        cash, revenue = two_accounts
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+        for i in range(3):
+            txn = _make_transaction_with_timestamp(
+                cash.id,
+                revenue.id,
+                datetime.datetime(2025, 1, i + 1, tzinfo=datetime.UTC),
+                description=f"Sale {i + 1}",
+            )
+            await repo.create(txn)
+
+        result = await repo.get_by_account_id(cash.id, limit=1)
+
+        assert len(result) == 1
+
+    async def test_offset_skips_rows(
+        self,
+        db_session: sa_async.AsyncSession,
+        two_accounts: tuple[models.Account, models.Account],
+    ) -> None:
+        """get_by_account_id with offset=1 skips the first transaction."""
+        cash, revenue = two_accounts
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+        for i in range(3):
+            txn = _make_transaction_with_timestamp(
+                cash.id,
+                revenue.id,
+                datetime.datetime(2025, 1, i + 1, tzinfo=datetime.UTC),
+                description=f"Sale {i + 1}",
+            )
+            await repo.create(txn)
+
+        result = await repo.get_by_account_id(cash.id, offset=1)
+
+        assert len(result) == 2
+
+    async def test_from_date_filters_transactions(
+        self,
+        db_session: sa_async.AsyncSession,
+        two_accounts: tuple[models.Account, models.Account],
+    ) -> None:
+        """get_by_account_id with from_date excludes earlier transactions."""
+        cash, revenue = two_accounts
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+        for i in range(3):
+            txn = _make_transaction_with_timestamp(
+                cash.id,
+                revenue.id,
+                datetime.datetime(2025, 1, i + 1, tzinfo=datetime.UTC),
+                description=f"Sale {i + 1}",
+            )
+            await repo.create(txn)
+
+        result = await repo.get_by_account_id(
+            cash.id,
+            from_date=datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
+        )
+
+        assert len(result) == 2
+        descriptions = {t.description for t in result}
+        assert "Sale 1" not in descriptions
+
+    async def test_to_date_filters_transactions(
+        self,
+        db_session: sa_async.AsyncSession,
+        two_accounts: tuple[models.Account, models.Account],
+    ) -> None:
+        """get_by_account_id with to_date excludes later transactions."""
+        cash, revenue = two_accounts
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+        for i in range(3):
+            txn = _make_transaction_with_timestamp(
+                cash.id,
+                revenue.id,
+                datetime.datetime(2025, 1, i + 1, tzinfo=datetime.UTC),
+                description=f"Sale {i + 1}",
+            )
+            await repo.create(txn)
+
+        result = await repo.get_by_account_id(
+            cash.id,
+            to_date=datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
+        )
+
+        assert len(result) == 2
+        descriptions = {t.description for t in result}
+        assert "Sale 3" not in descriptions
+
+    async def test_date_range_filters_transactions(
+        self,
+        db_session: sa_async.AsyncSession,
+        two_accounts: tuple[models.Account, models.Account],
+    ) -> None:
+        """from_date + to_date returns only transactions in range."""
+        cash, revenue = two_accounts
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+        for i in range(5):
+            txn = _make_transaction_with_timestamp(
+                cash.id,
+                revenue.id,
+                datetime.datetime(2025, 1, i + 1, tzinfo=datetime.UTC),
+                description=f"Sale {i + 1}",
+            )
+            await repo.create(txn)
+
+        result = await repo.get_by_account_id(
+            cash.id,
+            from_date=datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
+            to_date=datetime.datetime(2025, 1, 4, tzinfo=datetime.UTC),
+        )
+
+        assert len(result) == 3
+        descriptions = {t.description for t in result}
+        assert descriptions == {"Sale 2", "Sale 3", "Sale 4"}
+
+    async def test_no_limit_returns_all(
+        self,
+        db_session: sa_async.AsyncSession,
+        two_accounts: tuple[models.Account, models.Account],
+    ) -> None:
+        """get_by_account_id without limit returns all transactions."""
+        cash, revenue = two_accounts
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+        for i in range(3):
+            txn = _make_transaction_with_timestamp(
+                cash.id,
+                revenue.id,
+                datetime.datetime(2025, 1, i + 1, tzinfo=datetime.UTC),
+                description=f"Sale {i + 1}",
+            )
+            await repo.create(txn)
+
+        result = await repo.get_by_account_id(cash.id)
+
+        assert len(result) == 3


### PR DESCRIPTION
## Summary

- Add `limit`/`offset` pagination to `GET /api/accounts` and `GET /api/accounts/{id}/transactions` (SQL-level, optional, backward-compatible)
- Add `from_date`/`to_date` inclusive date filtering to `GET /api/accounts/{id}/transactions`
- Add `ORDER BY` for deterministic pagination (name for accounts, timestamp for transactions)
- Add OpenAPI `summary`/`description`/`response_description` to all 7 endpoints
- Add `Field(description=...)` to all Pydantic schema fields
- Update `docs/api-specification.md` with query parameter tables

## Test plan

- [x] 3 new integration tests for account repo pagination (limit, offset, no-limit)
- [x] 6 new integration tests for transaction repo pagination + date filtering
- [x] 3 new API tests for account pagination
- [x] 5 new API tests for transaction pagination + date filtering
- [x] All 116 tests pass (`make check`: lint + typecheck + tests)
- [ ] Verify `/docs` shows polished OpenAPI descriptions
- [ ] Verify `curl` with pagination/date params returns expected results

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)