### PR TITLE
fix: align ORM column names with production DB schema

### DIFF
--- a/alembic/versions/3365329fc747_create_initial_schema.py
+++ b/alembic/versions/3365329fc747_create_initial_schema.py
@@ -24,7 +24,7 @@ def upgrade() -> None:
         "accounts",
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
-        sa.Column("account_type", sa.String(), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -32,8 +32,8 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.CheckConstraint(
-            "account_type IN ('ASSET', 'LIABILITY', 'REVENUE', 'EXPENSE')",
-            name="ck_accounts_account_type",
+            "type IN ('ASSET', 'LIABILITY', 'REVENUE', 'EXPENSE')",
+            name="ck_accounts_type",
         ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("name"),
@@ -66,11 +66,11 @@ def upgrade() -> None:
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("transaction_id", sa.Uuid(), nullable=False),
         sa.Column("account_id", sa.Uuid(), nullable=False),
-        sa.Column("entry_type", sa.String(), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
         sa.Column("amount", sa.Numeric(), nullable=False),
         sa.CheckConstraint(
-            "entry_type IN ('DEBIT', 'CREDIT')",
-            name="ck_transaction_entries_entry_type",
+            "type IN ('DEBIT', 'CREDIT')",
+            name="ck_transaction_entries_type",
         ),
         sa.CheckConstraint(
             "amount > 0",

--- a/src/ledger/infrastructure/models.py
+++ b/src/ledger/infrastructure/models.py
@@ -30,6 +30,7 @@ class AccountModel(database.Base):
         nullable=False,
     )
     account_type: orm.Mapped[str] = orm.mapped_column(
+        "type",
         sa.String,
         nullable=False,
     )
@@ -41,8 +42,8 @@ class AccountModel(database.Base):
 
     __table_args__ = (
         sa.CheckConstraint(
-            sa.column("account_type").in_(ACCOUNT_TYPE_VALUES),
-            name="ck_accounts_account_type",
+            sa.column("type").in_(ACCOUNT_TYPE_VALUES),
+            name="ck_accounts_type",
         ),
     )
 
@@ -100,6 +101,7 @@ class TransactionEntryModel(database.Base):
         index=True,
     )
     entry_type: orm.Mapped[str] = orm.mapped_column(
+        "type",
         sa.String,
         nullable=False,
     )
@@ -114,8 +116,8 @@ class TransactionEntryModel(database.Base):
 
     __table_args__ = (
         sa.CheckConstraint(
-            sa.column("entry_type").in_(ENTRY_TYPE_VALUES),
-            name="ck_transaction_entries_entry_type",
+            sa.column("type").in_(ENTRY_TYPE_VALUES),
+            name="ck_transaction_entries_type",
         ),
         sa.CheckConstraint(
             sa.column("amount") > 0,

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -6,6 +6,8 @@ import sqlalchemy as sa
 import sqlalchemy.engine as sa_engine
 import testcontainers.postgres
 
+import ledger.infrastructure.models as orm_models
+
 
 def _make_alembic_config(sync_url: str) -> alembic.config.Config:
     """
@@ -84,7 +86,7 @@ class TestMigrations:
             account_cols = _get_table_columns(engine, "accounts")
             assert "id" in account_cols
             assert "name" in account_cols
-            assert "account_type" in account_cols
+            assert "type" in account_cols
             assert "created_at" in account_cols
 
             txn_cols = _get_table_columns(engine, "transactions")
@@ -97,7 +99,7 @@ class TestMigrations:
             assert "id" in entry_cols
             assert "transaction_id" in entry_cols
             assert "account_id" in entry_cols
-            assert "entry_type" in entry_cols
+            assert "type" in entry_cols
             assert "amount" in entry_cols
 
             engine.dispose()
@@ -117,5 +119,33 @@ class TestMigrations:
             entry_indexes = _get_indexes(engine, "transaction_entries")
             assert "transaction_id" in entry_indexes
             assert "account_id" in entry_indexes
+
+            engine.dispose()
+
+    def test_orm_columns_match_migration_schema(self) -> None:
+        """ORM model column names must match the DB columns created by migrations.
+
+        This catches drift between the ORM model and the migration (and
+        therefore the production database).  Without this test, the ORM
+        can silently generate SQL referencing columns that do not exist.
+        """
+        with testcontainers.postgres.PostgresContainer("postgres:16-alpine") as pg:
+            url = pg.get_connection_url()
+            cfg = _make_alembic_config(url)
+            alembic.command.upgrade(cfg, "head")
+
+            engine = sa.create_engine(url)
+
+            for model_cls in (
+                orm_models.AccountModel,
+                orm_models.TransactionModel,
+                orm_models.TransactionEntryModel,
+            ):
+                table_name = model_cls.__tablename__
+                db_cols = set(_get_table_columns(engine, table_name))
+                orm_cols = {c.name for c in model_cls.__table__.columns}
+                assert orm_cols == db_cols, (
+                    f"{table_name}: ORM columns {orm_cols} != DB columns {db_cols}"
+                )
 
             engine.dispose()


### PR DESCRIPTION
## Summary

- Fix `accounts.account_type does not exist` crash on `GET /api/accounts` (and all endpoints touching these columns)
- ORM model now explicitly maps `account_type` → DB column `type` and `entry_type` → DB column `type` via `mapped_column("type", ...)`
- Migration updated to create `type` columns (matching production DB)
- Check constraint names updated: `ck_accounts_type`, `ck_transaction_entries_type`
- New test `test_orm_columns_match_migration_schema` validates ORM metadata matches the migration-created schema, preventing future drift

## Root Cause

The production DB was created before the Alembic migration, with columns named `type`. The migration was later stamped as applied (`alembic stamp head`) without actually running. The ORM model defaulted `mapped_column()` to use the Python attribute name (`account_type`/`entry_type`) as the DB column name, creating a silent mismatch. Tests always passed because testcontainers creates a fresh DB from the migration.

## Test plan

- [x] All 117 tests pass (`make check`)
- [x] New `test_orm_columns_match_migration_schema` validates ORM ↔ DB column name alignment
- [ ] Verify `curl http://localhost:8000/api/accounts` works against production DB

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)