### PR TITLE
feat: data seeding script with 3 business scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down build lint typecheck test check run
+.PHONY: up down build lint typecheck test check run seed-data
 
 up:
 	docker compose up -d
@@ -26,3 +26,6 @@ check: lint typecheck test
 
 run:
 	docker compose run --rm --no-deps app uvicorn ledger.main:app --host 0.0.0.0 --port 8000
+
+seed-data:
+	docker compose run --rm app python -m ledger.scripts.seed

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ curl http://localhost:8000/health
 # {"status":"ok"}
 ```
 
+Load sample data (optional):
+
+```bash
+make seed-data
+```
+
+This creates 10 accounts and 7 transactions covering common bookkeeping scenarios. See [Use Cases](docs/use-cases.md) for details.
+
 Stop:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ See the top-level [README](../README.md) for quick-start instructions, API usage
 |---|---|
 | [Domain Model](./domain-model.md) | Entities (Account, Transaction, TransactionEntry), balance calculation rules, validation rules, worked examples |
 | [API Specification](./api-specification.md) | All 6 REST endpoints with request/response contracts, status codes, curl examples, error matrix |
+| [Use Cases](./use-cases.md) | 3 multi-step business scenarios with seed data, JSON payloads, and expected balances |
 
 ## Development
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,273 @@
+# Use Cases
+
+Three multi-step business scenarios that demonstrate double-entry bookkeeping with the Financial Ledger API.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Seeded Accounts](#seeded-accounts)
+- [Scenario 1: Purchase Office Supplies](#scenario-1-purchase-office-supplies)
+- [Scenario 2: Sell Goods on Credit](#scenario-2-sell-goods-on-credit)
+- [Scenario 3: Borrow Money from a Bank](#scenario-3-borrow-money-from-a-bank)
+- [Final Balances](#final-balances)
+- [See Also](#see-also)
+
+## Overview
+
+The seed script (`make seed-data`) loads all three scenarios into a running instance. You can also replay them manually with `curl` using the JSON payloads below.
+
+```bash
+# Load all scenarios at once
+make seed-data
+```
+
+Each scenario creates accounts and transactions that follow real-world accounting patterns. Every transaction balances (total debits = total credits), and the final balances satisfy the accounting equation:
+
+> **Assets = Liabilities + Equity**
+
+## Seeded Accounts
+
+| Account | Type |
+|---|---|
+| Cash | ASSET |
+| Office Supplies | EXPENSE |
+| Accounts Payable | LIABILITY |
+| Sales Revenue | REVENUE |
+| Accounts Receivable | ASSET |
+| Inventory | ASSET |
+| Cost of Goods Sold | EXPENSE |
+| Bank Loan | LIABILITY |
+| Loan Fees | EXPENSE |
+| Interest Expense | EXPENSE |
+
+Create them via the API:
+
+```bash
+curl -X POST http://localhost:8000/api/accounts \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Cash", "type": "ASSET"}'
+```
+
+Repeat for each account, changing the `name` and `type` values.
+
+## Scenario 1: Purchase Office Supplies
+
+A business buys $600 of office supplies, paying $200 cash and putting $400 on credit. Later, it pays the supplier.
+
+### Transaction 1: Purchase supplies (Mar 1)
+
+```bash
+curl -X POST http://localhost:8000/api/transactions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Purchase office supplies",
+    "date": "2026-03-01T10:00:00Z",
+    "entries": [
+      {"accountId": "<office-supplies-id>", "type": "DEBIT", "amount": 600.00},
+      {"accountId": "<cash-id>", "type": "CREDIT", "amount": 200.00},
+      {"accountId": "<accounts-payable-id>", "type": "CREDIT", "amount": 400.00}
+    ]
+  }'
+```
+
+| Account | Debit | Credit |
+|---|---|---|
+| Office Supplies | $600 | |
+| Cash | | $200 |
+| Accounts Payable | | $400 |
+
+### Transaction 2: Pay supplier (Mar 5)
+
+```bash
+curl -X POST http://localhost:8000/api/transactions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Pay office supply supplier",
+    "date": "2026-03-05T10:00:00Z",
+    "entries": [
+      {"accountId": "<accounts-payable-id>", "type": "DEBIT", "amount": 400.00},
+      {"accountId": "<cash-id>", "type": "CREDIT", "amount": 400.00}
+    ]
+  }'
+```
+
+| Account | Debit | Credit |
+|---|---|---|
+| Accounts Payable | $400 | |
+| Cash | | $400 |
+
+**Result:** Office Supplies balance is $600. Accounts Payable is zeroed out. Cash decreased by $600 total.
+
+## Scenario 2: Sell Goods on Credit
+
+A business purchases inventory, sells it on credit at a markup, and later collects payment.
+
+### Transaction 1: Purchase inventory (Mar 3)
+
+```bash
+curl -X POST http://localhost:8000/api/transactions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Purchase inventory for resale",
+    "date": "2026-03-03T10:00:00Z",
+    "entries": [
+      {"accountId": "<inventory-id>", "type": "DEBIT", "amount": 600.00},
+      {"accountId": "<cash-id>", "type": "CREDIT", "amount": 600.00}
+    ]
+  }'
+```
+
+| Account | Debit | Credit |
+|---|---|---|
+| Inventory | $600 | |
+| Cash | | $600 |
+
+### Transaction 2: Sell goods on credit (Mar 10)
+
+This compound transaction records both the revenue and the cost of goods sold:
+
+```bash
+curl -X POST http://localhost:8000/api/transactions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Sale of goods on credit",
+    "date": "2026-03-10T14:00:00Z",
+    "entries": [
+      {"accountId": "<accounts-receivable-id>", "type": "DEBIT", "amount": 1000.00},
+      {"accountId": "<sales-revenue-id>", "type": "CREDIT", "amount": 1000.00},
+      {"accountId": "<cogs-id>", "type": "DEBIT", "amount": 600.00},
+      {"accountId": "<inventory-id>", "type": "CREDIT", "amount": 600.00}
+    ]
+  }'
+```
+
+| Account | Debit | Credit |
+|---|---|---|
+| Accounts Receivable | $1,000 | |
+| Sales Revenue | | $1,000 |
+| Cost of Goods Sold | $600 | |
+| Inventory | | $600 |
+
+### Transaction 3: Customer pays (Mar 15)
+
+```bash
+curl -X POST http://localhost:8000/api/transactions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Customer payment for goods",
+    "date": "2026-03-15T09:00:00Z",
+    "entries": [
+      {"accountId": "<cash-id>", "type": "DEBIT", "amount": 1000.00},
+      {"accountId": "<accounts-receivable-id>", "type": "CREDIT", "amount": 1000.00}
+    ]
+  }'
+```
+
+| Account | Debit | Credit |
+|---|---|---|
+| Cash | $1,000 | |
+| Accounts Receivable | | $1,000 |
+
+**Result:** Revenue of $1,000 recorded, COGS of $600, Inventory zeroed out, Cash increased by $400 net, Accounts Receivable zeroed out.
+
+## Scenario 3: Borrow Money from a Bank
+
+A business takes a $1,000 loan with a $50 origination fee, then makes an interest payment.
+
+### Transaction 1: Loan disbursement (Mar 20)
+
+The bank deducts a $50 fee from the disbursement:
+
+```bash
+curl -X POST http://localhost:8000/api/transactions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Bank loan received",
+    "date": "2026-03-20T11:00:00Z",
+    "entries": [
+      {"accountId": "<cash-id>", "type": "DEBIT", "amount": 950.00},
+      {"accountId": "<loan-fees-id>", "type": "DEBIT", "amount": 50.00},
+      {"accountId": "<bank-loan-id>", "type": "CREDIT", "amount": 1000.00}
+    ]
+  }'
+```
+
+| Account | Debit | Credit |
+|---|---|---|
+| Cash | $950 | |
+| Loan Fees | $50 | |
+| Bank Loan | | $1,000 |
+
+### Transaction 2: Interest payment (Apr 1)
+
+```bash
+curl -X POST http://localhost:8000/api/transactions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Loan interest payment",
+    "date": "2026-04-01T10:00:00Z",
+    "entries": [
+      {"accountId": "<interest-expense-id>", "type": "DEBIT", "amount": 50.00},
+      {"accountId": "<cash-id>", "type": "CREDIT", "amount": 50.00}
+    ]
+  }'
+```
+
+| Account | Debit | Credit |
+|---|---|---|
+| Interest Expense | $50 | |
+| Cash | | $50 |
+
+**Result:** $1,000 liability recorded, $50 loan fee expensed, Cash increased by $900 net, $50 interest paid.
+
+## Final Balances
+
+After all 7 transactions, the ledger shows:
+
+| Account | Type | Balance |
+|---|---|---|
+| Cash | ASSET | $700.00 |
+| Office Supplies | EXPENSE | $600.00 |
+| Accounts Payable | LIABILITY | $0.00 |
+| Sales Revenue | REVENUE | $1,000.00 |
+| Accounts Receivable | ASSET | $0.00 |
+| Inventory | ASSET | $0.00 |
+| Cost of Goods Sold | EXPENSE | $600.00 |
+| Bank Loan | LIABILITY | $1,000.00 |
+| Loan Fees | EXPENSE | $50.00 |
+| Interest Expense | EXPENSE | $50.00 |
+
+### Accounting Equation
+
+```
+Assets = Liabilities + Equity
+
+Assets:
+  Cash               $700.00
+  Accounts Receivable   $0.00
+  Inventory             $0.00
+  ─────────────────────────────
+  Total Assets        $700.00
+
+Liabilities:
+  Accounts Payable      $0.00
+  Bank Loan         $1,000.00
+  ─────────────────────────────
+  Total Liabilities $1,000.00
+
+Equity (Revenue − Expenses):
+  Sales Revenue     $1,000.00
+  Office Supplies    −$600.00
+  Cost of Goods Sold −$600.00
+  Loan Fees           −$50.00
+  Interest Expense    −$50.00
+  ─────────────────────────────
+  Total Equity       −$300.00
+
+$700 = $1,000 + (−$300) ✓
+```
+
+## See Also
+
+- [Domain Model](./domain-model.md) -- entities, balance rules, and validation
+- [API Specification](./api-specification.md) -- endpoint contracts and error codes

--- a/src/ledger/scripts/__init__.py
+++ b/src/ledger/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""CLI scripts for the financial ledger (seeding, maintenance)."""

--- a/src/ledger/scripts/seed.py
+++ b/src/ledger/scripts/seed.py
@@ -1,0 +1,227 @@
+"""Seed the database with sample accounts and transactions.
+
+Demonstrates three real-world business scenarios:
+1. Purchase office supplies (cash + credit)
+2. Sell goods on credit (inventory purchase, sale, payment)
+3. Borrow money from a bank (loan disbursement, interest payment)
+
+Usage::
+
+    python -m ledger.scripts.seed
+"""
+
+import asyncio
+import datetime
+import decimal
+import os
+import uuid
+
+import sqlalchemy.ext.asyncio as sa_async
+
+import ledger.application.account_service as account_service_mod
+import ledger.application.transaction_service as transaction_service_mod
+import ledger.domain.enums as enums
+import ledger.domain.exceptions as exceptions
+import ledger.infrastructure.database as database
+import ledger.infrastructure.repositories.account_repo as account_repo_mod
+import ledger.infrastructure.repositories.transaction_repo as transaction_repo_mod
+
+_ACCOUNTS: list[tuple[str, enums.AccountType]] = [
+    ("Cash", enums.AccountType.ASSET),
+    ("Office Supplies", enums.AccountType.EXPENSE),
+    ("Accounts Payable", enums.AccountType.LIABILITY),
+    ("Sales Revenue", enums.AccountType.REVENUE),
+    ("Accounts Receivable", enums.AccountType.ASSET),
+    ("Inventory", enums.AccountType.ASSET),
+    ("Cost of Goods Sold", enums.AccountType.EXPENSE),
+    ("Bank Loan", enums.AccountType.LIABILITY),
+    ("Loan Fees", enums.AccountType.EXPENSE),
+    ("Interest Expense", enums.AccountType.EXPENSE),
+]
+
+
+def _entry(
+    account_id: uuid.UUID,
+    entry_type: enums.EntryType,
+    amount: str,
+) -> transaction_service_mod.EntryData:
+    """
+    Build an EntryData shorthand.
+
+    :param account_id: UUID of the account
+    :param entry_type: DEBIT or CREDIT
+    :param amount: decimal amount as string
+    :return: EntryData instance
+    """
+    return transaction_service_mod.EntryData(
+        account_id=account_id,
+        type=entry_type,
+        amount=decimal.Decimal(amount),
+    )
+
+
+async def seed(
+    session_factory: sa_async.async_sessionmaker[sa_async.AsyncSession],
+) -> None:
+    """
+    Populate the database with 10 accounts and 7 transactions.
+
+    Idempotent: skips account creation when names already exist and only
+    creates transactions when accounts were freshly created.
+
+    :param session_factory: async session factory bound to the target engine
+    """
+    dr = enums.EntryType.DEBIT
+    cr = enums.EntryType.CREDIT
+
+    ids: dict[str, uuid.UUID] = {}
+    created_new = False
+
+    # --- accounts ---
+    async with session_factory() as session:
+        acct_repo = account_repo_mod.SqlaAccountRepository(session)
+        acct_svc = account_service_mod.AccountService(account_repo=acct_repo)
+
+        for name, acct_type in _ACCOUNTS:
+            try:
+                result = await acct_svc.create_account(name, acct_type)
+                ids[name] = result.account.id
+                created_new = True
+            except exceptions.DuplicateAccountError:
+                pass
+
+        await session.commit()
+
+    if not created_new:
+        print("Seed data already exists -- skipping transactions.")
+        return
+
+    # If some accounts were created but others already existed, fetch all IDs
+    async with session_factory() as session:
+        acct_repo = account_repo_mod.SqlaAccountRepository(session)
+        all_accounts = await acct_repo.get_all()
+        for acct in all_accounts:
+            ids[acct.name] = acct.id
+
+    # --- transactions ---
+    transactions = [
+        # 1. Purchase office supplies: $200 cash + $400 on credit
+        (
+            "Purchase office supplies",
+            datetime.datetime(2026, 3, 1, 10, 0, tzinfo=datetime.UTC),
+            [
+                _entry(ids["Office Supplies"], dr, "600.00"),
+                _entry(ids["Cash"], cr, "200.00"),
+                _entry(ids["Accounts Payable"], cr, "400.00"),
+            ],
+        ),
+        # 2. Purchase inventory for resale
+        (
+            "Purchase inventory for resale",
+            datetime.datetime(2026, 3, 3, 10, 0, tzinfo=datetime.UTC),
+            [
+                _entry(ids["Inventory"], dr, "600.00"),
+                _entry(ids["Cash"], cr, "600.00"),
+            ],
+        ),
+        # 3. Pay office supply supplier
+        (
+            "Pay office supply supplier",
+            datetime.datetime(2026, 3, 5, 10, 0, tzinfo=datetime.UTC),
+            [
+                _entry(ids["Accounts Payable"], dr, "400.00"),
+                _entry(ids["Cash"], cr, "400.00"),
+            ],
+        ),
+        # 4. Sale of goods on credit
+        (
+            "Sale of goods on credit",
+            datetime.datetime(2026, 3, 10, 14, 0, tzinfo=datetime.UTC),
+            [
+                _entry(ids["Accounts Receivable"], dr, "1000.00"),
+                _entry(ids["Sales Revenue"], cr, "1000.00"),
+                _entry(ids["Cost of Goods Sold"], dr, "600.00"),
+                _entry(ids["Inventory"], cr, "600.00"),
+            ],
+        ),
+        # 5. Customer payment for goods
+        (
+            "Customer payment for goods",
+            datetime.datetime(2026, 3, 15, 9, 0, tzinfo=datetime.UTC),
+            [
+                _entry(ids["Cash"], dr, "1000.00"),
+                _entry(ids["Accounts Receivable"], cr, "1000.00"),
+            ],
+        ),
+        # 6. Bank loan received (with $50 origination fee)
+        (
+            "Bank loan received",
+            datetime.datetime(2026, 3, 20, 11, 0, tzinfo=datetime.UTC),
+            [
+                _entry(ids["Cash"], dr, "950.00"),
+                _entry(ids["Loan Fees"], dr, "50.00"),
+                _entry(ids["Bank Loan"], cr, "1000.00"),
+            ],
+        ),
+        # 7. Loan interest payment
+        (
+            "Loan interest payment",
+            datetime.datetime(2026, 4, 1, 10, 0, tzinfo=datetime.UTC),
+            [
+                _entry(ids["Interest Expense"], dr, "50.00"),
+                _entry(ids["Cash"], cr, "50.00"),
+            ],
+        ),
+    ]
+
+    async with session_factory() as session:
+        acct_repo = account_repo_mod.SqlaAccountRepository(session)
+        txn_repo = transaction_repo_mod.SqlaTransactionRepository(session)
+        txn_svc = transaction_service_mod.TransactionService(
+            account_repo=acct_repo,
+            transaction_repo=txn_repo,
+        )
+
+        for description, timestamp, entries in transactions:
+            await txn_svc.create_transaction(
+                description=description,
+                timestamp=timestamp,
+                entries_data=entries,
+            )
+
+        await session.commit()
+
+    # --- summary ---
+    async with session_factory() as session:
+        acct_repo = account_repo_mod.SqlaAccountRepository(session)
+        results = await acct_repo.get_all_with_balances()
+
+    print("Seed data loaded successfully!")
+    print()
+    print(f"{'Account':<25} {'Type':<12} {'Balance':>12}")
+    print("-" * 50)
+    for account, balance in results:
+        print(f"{account.name:<25} {account.type.value:<12} {balance:>12,.2f}")
+
+
+async def _main() -> None:
+    """
+    Entry point: read DATABASE_URL, create engine, and run seed.
+
+    :raises RuntimeError: if DATABASE_URL is not set
+    """
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url is None:
+        raise RuntimeError("DATABASE_URL environment variable is required")
+
+    engine = database.create_async_engine(database_url)
+    session_factory = database.create_async_session_factory(engine)
+
+    try:
+        await seed(session_factory)
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/tests/integration/test_seed.py
+++ b/tests/integration/test_seed.py
@@ -1,0 +1,82 @@
+"""Integration tests for the data-seeding script."""
+
+import collections.abc
+import decimal
+
+import pytest
+import sqlalchemy as sa
+import sqlalchemy.ext.asyncio as sa_async
+
+import ledger.infrastructure.repositories.account_repo as account_repo_mod
+import ledger.scripts.seed as seed_mod
+
+EXPECTED_BALANCES: dict[str, decimal.Decimal] = {
+    "Cash": decimal.Decimal("700.00"),
+    "Office Supplies": decimal.Decimal("600.00"),
+    "Accounts Payable": decimal.Decimal("0.00"),
+    "Sales Revenue": decimal.Decimal("1000.00"),
+    "Accounts Receivable": decimal.Decimal("0.00"),
+    "Inventory": decimal.Decimal("0.00"),
+    "Cost of Goods Sold": decimal.Decimal("600.00"),
+    "Bank Loan": decimal.Decimal("1000.00"),
+    "Loan Fees": decimal.Decimal("50.00"),
+    "Interest Expense": decimal.Decimal("50.00"),
+}
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_seed_data(
+    async_engine: sa_async.AsyncEngine,
+) -> collections.abc.AsyncGenerator[None, None]:
+    """
+    Remove all committed seed data after each test.
+
+    The seed function commits directly to the database, so unlike
+    ``db_session``-based tests the data persists across tests.
+
+    :param async_engine: session-scoped async engine
+    """
+    yield
+    async with async_engine.begin() as conn:
+        await conn.execute(sa.text("DELETE FROM transaction_entries"))
+        await conn.execute(sa.text("DELETE FROM transactions"))
+        await conn.execute(sa.text("DELETE FROM accounts"))
+
+
+@pytest.mark.asyncio
+async def test_seed_creates_accounts_with_correct_balances(
+    async_engine: sa_async.AsyncEngine,
+) -> None:
+    """Seed creates 10 accounts and 7 transactions with expected balances."""
+    session_factory = sa_async.async_sessionmaker(async_engine, expire_on_commit=False)
+
+    await seed_mod.seed(session_factory)
+
+    async with session_factory() as session:
+        repo = account_repo_mod.SqlaAccountRepository(session)
+        results = await repo.get_all_with_balances()
+        balances = {account.name: balance for account, balance in results}
+
+    assert len(balances) == len(EXPECTED_BALANCES)
+    for name, expected in EXPECTED_BALANCES.items():
+        assert balances[name] == expected, f"{name}: {balances[name]} != {expected}"
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(
+    async_engine: sa_async.AsyncEngine,
+) -> None:
+    """Running seed twice does not duplicate accounts or crash."""
+    session_factory = sa_async.async_sessionmaker(async_engine, expire_on_commit=False)
+
+    await seed_mod.seed(session_factory)
+    await seed_mod.seed(session_factory)
+
+    async with session_factory() as session:
+        repo = account_repo_mod.SqlaAccountRepository(session)
+        results = await repo.get_all_with_balances()
+        balances = {account.name: balance for account, balance in results}
+
+    assert len(balances) == len(EXPECTED_BALANCES)
+    for name, expected in EXPECTED_BALANCES.items():
+        assert balances[name] == expected, f"{name}: {balances[name]} != {expected}"


### PR DESCRIPTION
## Summary

- Add `make seed-data` script that populates 10 accounts and 7 transactions covering 3 real-world scenarios: office supply purchase, inventory sale on credit, and bank loan with interest
- Idempotent: safely re-runnable (skips existing accounts, only creates transactions on fresh seed)
- Add `docs/use-cases.md` with full JSON payloads, T-account tables, and accounting equation verification
- Integration tests verify all 10 expected balances and idempotent behavior

Closes #27

## Test plan

- [x] `make lint` — all checks passed
- [x] `make typecheck` — no issues
- [x] `make test` — 118 tests pass (2 new seed tests)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)