### PR TITLE
feat: database management make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: up down build lint typecheck test check run seed-data
+.PHONY: up down build lint typecheck test check run seed-data \
+       db-reset db-migrate db-revision db-shell db-dump db-restore
 
 up:
 	docker compose up -d
@@ -29,3 +30,28 @@ run:
 
 seed-data:
 	docker compose run --rm app python -m ledger.scripts.seed
+
+# ── Database management ──────────────────────────────────────────────
+
+db-reset:
+	@echo "WARNING: This will delete ALL data in the database."
+	@read -p "Type 'yes' to confirm: " confirm && [ "$$confirm" = "yes" ] || (echo "Aborted." && exit 1)
+	docker compose run --rm app alembic downgrade base
+	docker compose run --rm app alembic upgrade head
+	@echo "Database reset complete."
+
+db-migrate:
+	docker compose run --rm app alembic upgrade head
+
+db-revision:
+	docker compose run --rm app alembic revision --autogenerate -m "$(msg)"
+
+db-shell:
+	docker compose exec db psql -U ledger -d ledger
+
+db-dump:
+	docker compose exec db pg_dump -U ledger ledger > dump_$$(date +%Y%m%d_%H%M%S).sql
+	@echo "Dump saved to dump_$$(date +%Y%m%d_%H%M%S).sql"
+
+db-restore:
+	docker compose exec -T db psql -U ledger -d ledger < $(file)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ make down
 
 Use `docker compose run --rm app <command>` to run commands inside the container.
 
+### Database Management
+
+```bash
+make db-migrate                            # Apply pending migrations
+make db-revision msg="add user table"      # Generate new migration
+make db-shell                              # Open psql in Postgres container
+make db-reset                              # Drop all data + re-migrate (confirms first)
+make db-dump                               # Backup to timestamped .sql file
+make db-restore file=dump_20260305.sql     # Restore from backup
+```
+
 ## Running Tests
 
 Tests use testcontainers to spin up an isolated PostgreSQL instance per session:

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -7,6 +7,7 @@
 - [TDD Workflow](#tdd-workflow)
 - [Running Tests](#running-tests)
 - [Database Migrations](#database-migrations)
+- [Database Management](#database-management)
 - [Code Quality](#code-quality)
 - [Project Conventions](#project-conventions)
 - [Related Documents](#related-documents)
@@ -173,11 +174,11 @@ make test
 Migrations use Alembic and run inside Docker.
 
 ```bash
-# Generate a new migration (after changing ORM models)
-docker compose run --rm app alembic revision --autogenerate -m "description"
-
 # Apply all pending migrations
-docker compose run --rm app alembic upgrade head
+make db-migrate
+
+# Generate a new migration (after changing ORM models)
+make db-revision msg="add user table"
 
 # Rollback one migration
 docker compose run --rm app alembic downgrade -1
@@ -190,6 +191,22 @@ docker compose run --rm app alembic history
 ```
 
 Alembic reads `DATABASE_URL` from the environment. See [Project Setup: Configuration Files](./project-setup.md#configuration-files).
+
+## Database Management
+
+```bash
+# Open psql shell in the running Postgres container
+make db-shell
+
+# Reset database (drop all data, re-run migrations -- asks for confirmation)
+make db-reset
+
+# Backup database to a timestamped SQL file
+make db-dump
+
+# Restore from a backup file
+make db-restore file=dump_20260305_120000.sql
+```
 
 ## Code Quality
 

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -227,6 +227,13 @@ The runner waits for the health check to pass before running tests. `DATABASE_UR
 | `make test` | `pytest -v` | Requires DB |
 | `make check` | lint + typecheck + test | Full validation |
 | `make run` | Start uvicorn directly | `--no-deps` |
+| `make seed-data` | Load sample accounts + transactions | Requires DB |
+| `make db-reset` | Downgrade + re-migrate (with confirmation) | **Destructive** |
+| `make db-migrate` | `alembic upgrade head` | Apply pending migrations |
+| `make db-revision` | `alembic revision --autogenerate` | Pass `msg=` |
+| `make db-shell` | `psql` inside Postgres container | Interactive |
+| `make db-dump` | `pg_dump` to timestamped `.sql` file | Backup |
+| `make db-restore` | Restore from `.sql` file | Pass `file=` |
 
 ## Configuration Files
 


### PR DESCRIPTION
## Summary

- Add 6 new `make` targets for database management:
  - `db-reset` — drop all data and re-run migrations (with interactive confirmation prompt)
  - `db-migrate` — apply pending Alembic migrations standalone
  - `db-revision` — auto-generate new migration (`make db-revision msg="..."`)
  - `db-shell` — open `psql` inside the Postgres container
  - `db-dump` — backup to timestamped `.sql` file
  - `db-restore` — restore from backup (`make db-restore file=...`)
- Update README.md with Database Management section
- Update development guide with Database Management section + migration shortcuts
- Update project-setup.md Makefile targets table

Closes #25

## Test plan

- [x] `make lint` — all checks passed
- [x] `make typecheck` — no issues
- [x] `make test` — 118 tests pass
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)