### PR TITLE
feat: paginated envelopes, global transactions, CORS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ See the top-level [README](../README.md) for quick-start instructions, API usage
 | Document | Description |
 |---|---|
 | [Domain Model](./domain-model.md) | Entities (Account, Transaction, TransactionEntry), balance calculation rules, validation rules, worked examples |
-| [API Specification](./api-specification.md) | All 6 REST endpoints with request/response contracts, status codes, curl examples, error matrix |
+| [API Specification](./api-specification.md) | All 7 REST endpoints with request/response contracts, paginated envelopes, CORS config, status codes, curl examples, error matrix |
 | [Use Cases](./use-cases.md) | 3 multi-step business scenarios with seed data, JSON payloads, and expected balances |
 
 ## Development

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 - [Overview](#overview)
 - [Base URL](#base-url)
+- [CORS](#cors)
 - [Common Response Formats](#common-response-formats)
 - [Account Endpoints](#account-endpoints)
   - [POST /api/accounts](#post-apiaccounts)
@@ -10,6 +11,7 @@
   - [GET /api/accounts/{id}](#get-apiaccountsid)
 - [Transaction Endpoints](#transaction-endpoints)
   - [POST /api/transactions](#post-apitransactions)
+  - [GET /api/transactions](#get-apitransactions)
   - [GET /api/transactions/{id}](#get-apitransactionsid)
   - [GET /api/accounts/{id}/transactions](#get-apiaccountsidtransactions)
 - [Error Responses](#error-responses)
@@ -17,7 +19,7 @@
 
 ## Overview
 
-The Financial Ledger API exposes 6 REST endpoints for managing accounts and transactions. All request/response bodies use JSON. Monetary amounts are serialized as strings with 2 decimal places to avoid floating-point precision issues.
+The Financial Ledger API exposes 7 REST endpoints for managing accounts and transactions. All request/response bodies use JSON. Monetary amounts are serialized as strings with 2 decimal places to avoid floating-point precision issues.
 
 ## Base URL
 
@@ -25,7 +27,37 @@ The Financial Ledger API exposes 6 REST endpoints for managing accounts and tran
 http://localhost:8000/api
 ```
 
+## CORS
+
+Cross-Origin Resource Sharing is enabled via the `CORS_ORIGINS` environment variable.
+
+| Setting | Default |
+|---|---|
+| `CORS_ORIGINS` | `http://localhost:5173,http://localhost:3000` |
+
+Set to a comma-separated list of allowed origins. All HTTP methods and headers are permitted for listed origins. Credentials are allowed.
+
 ## Common Response Formats
+
+### Paginated Envelope
+
+List endpoints (`GET /api/accounts`, `GET /api/transactions`, `GET /api/accounts/{id}/transactions`) return a paginated envelope:
+
+```json
+{
+  "items": [ ... ],
+  "total": 47,
+  "limit": 10,
+  "offset": 0
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `items` | array | Page of results |
+| `total` | integer | Total count (ignoring limit/offset) |
+| `limit` | integer \| null | Requested limit (`null` when not specified) |
+| `offset` | integer | Requested offset |
 
 ### Account Response
 
@@ -122,7 +154,7 @@ List all accounts with their computed balances. Supports optional pagination. Re
 
 | Status | Body | When |
 |---|---|---|
-| `200 OK` | Array of account responses | Always (empty array if none) |
+| `200 OK` | Paginated envelope of account responses | Always (empty items if none) |
 | `422 Unprocessable Entity` | Validation errors | Invalid query parameter values |
 
 **Examples:**
@@ -136,20 +168,25 @@ curl "http://localhost:8000/api/accounts?limit=2&offset=0"
 ```
 
 ```json
-[
-  {
-    "id": "uuid-1",
-    "name": "Cash",
-    "type": "ASSET",
-    "balance": "1350.00"
-  },
-  {
-    "id": "uuid-2",
-    "name": "Revenue",
-    "type": "REVENUE",
-    "balance": "500.00"
-  }
-]
+{
+  "items": [
+    {
+      "id": "uuid-1",
+      "name": "Cash",
+      "type": "ASSET",
+      "balance": "1350.00"
+    },
+    {
+      "id": "uuid-2",
+      "name": "Revenue",
+      "type": "REVENUE",
+      "balance": "500.00"
+    }
+  ],
+  "total": 5,
+  "limit": 2,
+  "offset": 0
+}
 ```
 
 ---
@@ -250,6 +287,38 @@ curl -X POST http://localhost:8000/api/transactions \
 
 ---
 
+### GET /api/transactions
+
+List all transactions with optional pagination and date filtering. Results are ordered by timestamp ascending.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Constraints | Description |
+|---|---|---|---|---|
+| `limit` | integer | *(none — return all)* | 1–100 | Maximum number of transactions to return |
+| `offset` | integer | `0` | >= 0 | Number of transactions to skip |
+| `from_date` | datetime | *(none)* | ISO 8601 | Inclusive lower bound on transaction timestamp |
+| `to_date` | datetime | *(none)* | ISO 8601 | Inclusive upper bound on transaction timestamp |
+
+**Response:**
+
+| Status | Body | When |
+|---|---|---|
+| `200 OK` | Paginated envelope of transaction responses | Always (empty items if none) |
+| `422 Unprocessable Entity` | Validation errors | Invalid query parameter values |
+
+**Examples:**
+
+```bash
+# All transactions
+curl http://localhost:8000/api/transactions
+
+# Paginated with date filtering
+curl "http://localhost:8000/api/transactions?from_date=2025-01-01T00:00:00&to_date=2025-12-31T23:59:59&limit=10"
+```
+
+---
+
 ### GET /api/transactions/{id}
 
 Get a single transaction with all its entries.
@@ -298,7 +367,7 @@ Get transactions that affect a given account (i.e., have at least one entry refe
 
 | Status | Body | When |
 |---|---|---|
-| `200 OK` | Array of transaction responses | Account exists (empty array if no transactions) |
+| `200 OK` | Paginated envelope of transaction responses | Account exists (empty items if no transactions) |
 | `404 Not Found` | Error detail | Account does not exist |
 | `422 Unprocessable Entity` | Validation errors | Invalid query parameter values |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,8 +80,9 @@ Orchestrates use cases by combining domain logic with repository calls.
 | Module | Purpose |
 |---|---|
 | `interfaces.py` | Repository protocols (`AccountRepository`, `TransactionRepository`) using `typing.Protocol`. `AccountRepository` includes `get_with_balance()` and `get_all_with_balances()` for SQL-aggregated balance retrieval. |
-| `account_service.py` | `AccountService`: create account, get account with balance, list accounts. Returns `AccountWithBalance` DTO. Depends only on `AccountRepository` (balance is computed at the repository layer via SQL aggregation). |
-| `transaction_service.py` | `TransactionService`: create transaction (validate accounts + entries, persist), get by ID, get by account. Uses `EntryData` DTO. |
+| `pagination.py` | `PaginatedResult[T]` frozen dataclass -- generic paginated container (items + total count). Used by services to return paginated data. |
+| `account_service.py` | `AccountService`: create account, get account with balance, list accounts. Returns `AccountWithBalance` DTO (or `PaginatedResult[AccountWithBalance]` for lists). Depends only on `AccountRepository` (balance is computed at the repository layer via SQL aggregation). |
+| `transaction_service.py` | `TransactionService`: create transaction (validate accounts + entries, persist), get by ID, get by account, list all. Uses `EntryData` DTO, returns `PaginatedResult` for list operations. |
 
 **Rules:**
 - Depends on `domain` (uses entities and business rules)
@@ -114,8 +115,8 @@ Thin HTTP interface. No business logic.
 | Module | Purpose |
 |---|---|
 | `routers/accounts.py` | Account endpoints: `POST /api/accounts`, `GET /api/accounts`, `GET /api/accounts/{id}` |
-| `routers/transactions.py` | Transaction endpoints: `POST /api/transactions`, `GET /api/transactions/{id}`, `GET /api/accounts/{id}/transactions` |
-| `schemas.py` | Pydantic v2 request/response models for accounts and transactions (with camelCase aliases) |
+| `routers/transactions.py` | Transaction endpoints: `POST /api/transactions`, `GET /api/transactions`, `GET /api/transactions/{id}`, `GET /api/accounts/{id}/transactions` |
+| `schemas.py` | Pydantic v2 request/response models for accounts and transactions (with camelCase aliases), paginated envelope schemas (`PaginatedAccountResponse`, `PaginatedTransactionResponse`) |
 | `dependencies.py` | FastAPI DI chain: `get_session` → repos → `get_account_service` / `get_transaction_service` |
 | `exception_handlers.py` | Maps domain exceptions to HTTP status codes (404, 409, 400) |
 
@@ -163,6 +164,7 @@ src/ledger/
 ├── application/                # MIDDLE - Use cases
 │   ├── __init__.py
 │   ├── interfaces.py           # Repository protocols (typing.Protocol)
+│   ├── pagination.py           # PaginatedResult[T] generic container
 │   ├── account_service.py      # Account use cases
 │   └── transaction_service.py  # Transaction use cases
 ├── infrastructure/             # OUTER - DB, ORM
@@ -183,7 +185,7 @@ src/ledger/
 │       ├── __init__.py
 │       ├── accounts.py         # /api/accounts
 │       └── transactions.py     # /api/transactions
-└── main.py                     # App factory with async lifespan (DB engine/session)
+└── main.py                     # App factory with async lifespan (DB engine/session), CORS middleware
 ```
 
 ## Request Flow

--- a/src/ledger/api/routers/accounts.py
+++ b/src/ledger/api/routers/accounts.py
@@ -58,11 +58,11 @@ async def create_account(
 
 @router.get(
     "",
-    response_model=list[schemas.AccountResponse],
+    response_model=schemas.PaginatedAccountResponse,
     summary="List accounts",
     description="Retrieve all accounts with their balances computed via "
     "SQL aggregation. Supports optional pagination via limit and offset.",
-    response_description="Array of accounts with computed balances.",
+    response_description="Paginated envelope of accounts with computed balances.",
 )
 async def list_accounts(
     service: typing.Annotated[
@@ -79,17 +79,22 @@ async def list_accounts(
         int,
         fastapi.Query(ge=0, description="Number of accounts to skip."),
     ] = 0,
-) -> list[schemas.AccountResponse]:
+) -> schemas.PaginatedAccountResponse:
     """
     List all accounts with computed balances.
 
     :param service: injected account service
     :param limit: maximum number of accounts to return (None = all)
     :param offset: number of accounts to skip
-    :return: list of accounts with balances
+    :return: paginated envelope of accounts with balances
     """
-    results = await service.get_all(limit=limit, offset=offset)
-    return [_to_response(r) for r in results]
+    result = await service.get_all(limit=limit, offset=offset)
+    return schemas.PaginatedAccountResponse(
+        items=[_to_response(r) for r in result.items],
+        total=result.total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.get(

--- a/src/ledger/api/routers/transactions.py
+++ b/src/ledger/api/routers/transactions.py
@@ -94,6 +94,67 @@ async def create_transaction(
 
 
 @router.get(
+    "",
+    response_model=schemas.PaginatedTransactionResponse,
+    response_model_by_alias=True,
+    summary="List transactions",
+    description="Retrieve all transactions with optional pagination and date "
+    "filtering. Results are ordered by timestamp ascending.",
+    response_description="Paginated envelope of transactions with entries.",
+)
+async def list_transactions(
+    service: typing.Annotated[
+        transaction_service.TransactionService,
+        fastapi.Depends(dependencies.get_transaction_service),
+    ],
+    limit: typing.Annotated[
+        int | None,
+        fastapi.Query(
+            ge=1, le=100, description="Maximum number of transactions to return."
+        ),
+    ] = None,
+    offset: typing.Annotated[
+        int,
+        fastapi.Query(ge=0, description="Number of transactions to skip."),
+    ] = 0,
+    from_date: typing.Annotated[
+        datetime.datetime | None,
+        fastapi.Query(
+            description="Inclusive lower bound on transaction timestamp (ISO 8601)."
+        ),
+    ] = None,
+    to_date: typing.Annotated[
+        datetime.datetime | None,
+        fastapi.Query(
+            description="Inclusive upper bound on transaction timestamp (ISO 8601)."
+        ),
+    ] = None,
+) -> schemas.PaginatedTransactionResponse:
+    """
+    List all transactions with optional filtering.
+
+    :param service: injected transaction service
+    :param limit: maximum number of transactions to return (None = all)
+    :param offset: number of transactions to skip
+    :param from_date: inclusive lower bound on transaction timestamp
+    :param to_date: inclusive upper bound on transaction timestamp
+    :return: paginated envelope of transactions with entries
+    """
+    result = await service.get_all(
+        limit=limit,
+        offset=offset,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    return schemas.PaginatedTransactionResponse(
+        items=[_txn_to_response(t) for t in result.items],
+        total=result.total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get(
     "/{transaction_id}",
     response_model=schemas.TransactionResponse,
     response_model_by_alias=True,
@@ -122,13 +183,13 @@ async def get_transaction(
 
 @account_transactions_router.get(
     "/{account_id}/transactions",
-    response_model=list[schemas.TransactionResponse],
+    response_model=schemas.PaginatedTransactionResponse,
     response_model_by_alias=True,
     summary="List account transactions",
     description="Retrieve transactions affecting a given account. Supports "
     "pagination via limit/offset and date filtering via from_date/to_date "
     "(inclusive). Results are ordered by timestamp ascending.",
-    response_description="Array of transactions with all entries.",
+    response_description="Paginated envelope of transactions with all entries.",
 )
 async def get_account_transactions(
     account_id: uuid.UUID,
@@ -158,7 +219,7 @@ async def get_account_transactions(
             description="Inclusive upper bound on transaction timestamp (ISO 8601)."
         ),
     ] = None,
-) -> list[schemas.TransactionResponse]:
+) -> schemas.PaginatedTransactionResponse:
     """
     Retrieve transactions affecting a given account.
 
@@ -168,13 +229,18 @@ async def get_account_transactions(
     :param offset: number of transactions to skip
     :param from_date: inclusive lower bound on transaction timestamp
     :param to_date: inclusive upper bound on transaction timestamp
-    :return: list of transactions with entries
+    :return: paginated envelope of transactions with entries
     """
-    results = await service.get_by_account_id(
+    result = await service.get_by_account_id(
         account_id,
         limit=limit,
         offset=offset,
         from_date=from_date,
         to_date=to_date,
     )
-    return [_txn_to_response(r) for r in results]
+    return schemas.PaginatedTransactionResponse(
+        items=[_txn_to_response(r) for r in result.items],
+        total=result.total,
+        limit=limit,
+        offset=offset,
+    )

--- a/src/ledger/api/schemas.py
+++ b/src/ledger/api/schemas.py
@@ -92,3 +92,33 @@ class TransactionResponse(pydantic.BaseModel):
     entries: list[TransactionEntryResponse] = pydantic.Field(
         description="All debit and credit entries for this transaction."
     )
+
+
+class PaginatedAccountResponse(pydantic.BaseModel):
+    """Paginated envelope for account list responses."""
+
+    items: list[AccountResponse] = pydantic.Field(
+        description="Page of account results."
+    )
+    total: int = pydantic.Field(
+        description="Total number of accounts (ignoring limit/offset)."
+    )
+    limit: int | None = pydantic.Field(
+        description="Maximum number of items requested (None = all)."
+    )
+    offset: int = pydantic.Field(description="Number of items skipped.")
+
+
+class PaginatedTransactionResponse(pydantic.BaseModel):
+    """Paginated envelope for transaction list responses."""
+
+    items: list[TransactionResponse] = pydantic.Field(
+        description="Page of transaction results."
+    )
+    total: int = pydantic.Field(
+        description="Total number of transactions (ignoring limit/offset)."
+    )
+    limit: int | None = pydantic.Field(
+        description="Maximum number of items requested (None = all)."
+    )
+    offset: int = pydantic.Field(description="Number of items skipped.")

--- a/src/ledger/application/account_service.py
+++ b/src/ledger/application/account_service.py
@@ -5,6 +5,7 @@ import decimal
 import uuid
 
 import ledger.application.interfaces as interfaces
+import ledger.application.pagination as pagination
 import ledger.domain.enums as enums
 import ledger.domain.exceptions as exceptions
 import ledger.domain.models as models
@@ -79,18 +80,19 @@ class AccountService:
         self,
         limit: int | None = None,
         offset: int = 0,
-    ) -> list[AccountWithBalance]:
+    ) -> pagination.PaginatedResult[AccountWithBalance]:
         """
         Retrieve all accounts with balances computed via SQL aggregation.
 
         :param limit: maximum number of accounts to return (None = all)
         :param offset: number of accounts to skip
-        :return: list of accounts with their balances
+        :return: paginated result of accounts with their balances
         """
-        results = await self._account_repo.get_all_with_balances(
+        results, total = await self._account_repo.get_all_with_balances(
             limit=limit, offset=offset
         )
-        return [
+        items = [
             AccountWithBalance(account=account, balance=balance)
             for account, balance in results
         ]
+        return pagination.PaginatedResult(items=items, total=total)

--- a/src/ledger/application/interfaces.py
+++ b/src/ledger/application/interfaces.py
@@ -62,13 +62,13 @@ class AccountRepository(typing.Protocol):
         self,
         limit: int | None = None,
         offset: int = 0,
-    ) -> list[tuple[models.Account, decimal.Decimal]]:
+    ) -> tuple[list[tuple[models.Account, decimal.Decimal]], int]:
         """
         Retrieve all accounts with their computed balances via SQL aggregation.
 
         :param limit: maximum number of accounts to return (None = all)
         :param offset: number of accounts to skip
-        :return: list of (account, balance) tuples
+        :return: tuple of (list of (account, balance) tuples, total count)
         """
         ...
 
@@ -101,7 +101,7 @@ class TransactionRepository(typing.Protocol):
         offset: int = 0,
         from_date: datetime.datetime | None = None,
         to_date: datetime.datetime | None = None,
-    ) -> list[models.Transaction]:
+    ) -> tuple[list[models.Transaction], int]:
         """
         Retrieve transactions that have at least one entry for the given account.
 
@@ -113,6 +113,24 @@ class TransactionRepository(typing.Protocol):
         :param offset: number of transactions to skip
         :param from_date: inclusive lower bound on transaction timestamp
         :param to_date: inclusive upper bound on transaction timestamp
-        :return: list of transactions involving the account
+        :return: tuple of (list of transactions, total count)
+        """
+        ...
+
+    async def get_all(
+        self,
+        limit: int | None = None,
+        offset: int = 0,
+        from_date: datetime.datetime | None = None,
+        to_date: datetime.datetime | None = None,
+    ) -> tuple[list[models.Transaction], int]:
+        """
+        Retrieve all transactions with optional pagination and date filtering.
+
+        :param limit: maximum number of transactions to return (None = all)
+        :param offset: number of transactions to skip
+        :param from_date: inclusive lower bound on transaction timestamp
+        :param to_date: inclusive upper bound on transaction timestamp
+        :return: tuple of (list of transactions, total count)
         """
         ...

--- a/src/ledger/application/pagination.py
+++ b/src/ledger/application/pagination.py
@@ -1,0 +1,14 @@
+"""Generic paginated result container for application-layer use cases."""
+
+import dataclasses
+import typing
+
+T = typing.TypeVar("T")
+
+
+@dataclasses.dataclass(frozen=True)
+class PaginatedResult(typing.Generic[T]):
+    """A page of items paired with the total count before pagination."""
+
+    items: list[T]
+    total: int

--- a/src/ledger/application/transaction_service.py
+++ b/src/ledger/application/transaction_service.py
@@ -6,6 +6,7 @@ import decimal
 import uuid
 
 import ledger.application.interfaces as interfaces
+import ledger.application.pagination as pagination
 import ledger.domain.enums as enums
 import ledger.domain.exceptions as exceptions
 import ledger.domain.models as models
@@ -110,7 +111,7 @@ class TransactionService:
         offset: int = 0,
         from_date: datetime.datetime | None = None,
         to_date: datetime.datetime | None = None,
-    ) -> list[models.Transaction]:
+    ) -> pagination.PaginatedResult[models.Transaction]:
         """
         Retrieve transactions involving a given account with optional filtering.
 
@@ -119,16 +120,41 @@ class TransactionService:
         :param offset: number of transactions to skip
         :param from_date: inclusive lower bound on transaction timestamp
         :param to_date: inclusive upper bound on transaction timestamp
-        :return: list of transactions with entries
+        :return: paginated result of transactions with entries
         :raises AccountNotFoundError: if the account does not exist
         """
         account = await self._account_repo.get_by_id(account_id)
         if account is None:
             raise exceptions.AccountNotFoundError(f"Account {account_id} not found")
-        return await self._transaction_repo.get_by_account_id(
+        items, total = await self._transaction_repo.get_by_account_id(
             account_id,
             limit=limit,
             offset=offset,
             from_date=from_date,
             to_date=to_date,
         )
+        return pagination.PaginatedResult(items=items, total=total)
+
+    async def get_all(
+        self,
+        limit: int | None = None,
+        offset: int = 0,
+        from_date: datetime.datetime | None = None,
+        to_date: datetime.datetime | None = None,
+    ) -> pagination.PaginatedResult[models.Transaction]:
+        """
+        Retrieve all transactions with optional pagination and date filtering.
+
+        :param limit: maximum number of transactions to return (None = all)
+        :param offset: number of transactions to skip
+        :param from_date: inclusive lower bound on transaction timestamp
+        :param to_date: inclusive upper bound on transaction timestamp
+        :return: paginated result of transactions with entries
+        """
+        items, total = await self._transaction_repo.get_all(
+            limit=limit,
+            offset=offset,
+            from_date=from_date,
+            to_date=to_date,
+        )
+        return pagination.PaginatedResult(items=items, total=total)

--- a/src/ledger/infrastructure/repositories/account_repo.py
+++ b/src/ledger/infrastructure/repositories/account_repo.py
@@ -122,14 +122,19 @@ class SqlaAccountRepository:
         self,
         limit: int | None = None,
         offset: int = 0,
-    ) -> list[tuple[models.Account, decimal.Decimal]]:
+    ) -> tuple[list[tuple[models.Account, decimal.Decimal]], int]:
         """
         Retrieve all accounts with their computed balances via SQL aggregation.
 
         :param limit: maximum number of accounts to return (None = all)
         :param offset: number of accounts to skip
-        :return: list of (account, balance) tuples
+        :return: tuple of (list of (account, balance) tuples, total count)
         """
+        count_result = await self._session.execute(
+            sa.select(sa.func.count()).select_from(orm_models.AccountModel)
+        )
+        total = count_result.scalar_one()
+
         stmt = (
             sa.select(
                 orm_models.AccountModel.id,
@@ -153,7 +158,7 @@ class SqlaAccountRepository:
         if limit is not None:
             stmt = stmt.limit(limit)
         result = await self._session.execute(stmt)
-        return [
+        items = [
             (
                 models.Account(
                     id=row.id,
@@ -164,6 +169,7 @@ class SqlaAccountRepository:
             )
             for row in result.all()
         ]
+        return items, total
 
     @staticmethod
     def _balance_expression() -> sa.Label[decimal.Decimal]:

--- a/src/ledger/infrastructure/repositories/transaction_repo.py
+++ b/src/ledger/infrastructure/repositories/transaction_repo.py
@@ -56,7 +56,7 @@ class SqlaTransactionRepository:
         offset: int = 0,
         from_date: datetime.datetime | None = None,
         to_date: datetime.datetime | None = None,
-    ) -> list[models.Transaction]:
+    ) -> tuple[list[models.Transaction], int]:
         """
         Retrieve transactions that have at least one entry for the given account.
 
@@ -68,8 +68,24 @@ class SqlaTransactionRepository:
         :param offset: number of transactions to skip
         :param from_date: inclusive lower bound on transaction timestamp
         :param to_date: inclusive upper bound on transaction timestamp
-        :return: list of transactions involving the account
+        :return: tuple of (list of transactions, total count)
         """
+        count_stmt = (
+            sa.select(sa.func.count(sa.distinct(orm_models.TransactionModel.id)))
+            .join(orm_models.TransactionEntryModel)
+            .where(orm_models.TransactionEntryModel.account_id == account_id)
+        )
+        if from_date is not None:
+            count_stmt = count_stmt.where(
+                orm_models.TransactionModel.timestamp >= from_date
+            )
+        if to_date is not None:
+            count_stmt = count_stmt.where(
+                orm_models.TransactionModel.timestamp <= to_date
+            )
+        count_result = await self._session.execute(count_stmt)
+        total = count_result.scalar_one()
+
         stmt = (
             sa.select(orm_models.TransactionModel)
             .join(orm_models.TransactionEntryModel)
@@ -88,4 +104,44 @@ class SqlaTransactionRepository:
             stmt = stmt.limit(limit)
         result = await self._session.execute(stmt)
         rows = result.scalars().all()
-        return [mappers.transaction_to_domain(r) for r in rows]
+        return [mappers.transaction_to_domain(r) for r in rows], total
+
+    async def get_all(
+        self,
+        limit: int | None = None,
+        offset: int = 0,
+        from_date: datetime.datetime | None = None,
+        to_date: datetime.datetime | None = None,
+    ) -> tuple[list[models.Transaction], int]:
+        """
+        Retrieve all transactions with optional pagination and date filtering.
+
+        :param limit: maximum number of transactions to return (None = all)
+        :param offset: number of transactions to skip
+        :param from_date: inclusive lower bound on transaction timestamp
+        :param to_date: inclusive upper bound on transaction timestamp
+        :return: tuple of (list of transactions, total count)
+        """
+        count_stmt = sa.select(sa.func.count()).select_from(orm_models.TransactionModel)
+        if from_date is not None:
+            count_stmt = count_stmt.where(
+                orm_models.TransactionModel.timestamp >= from_date
+            )
+        if to_date is not None:
+            count_stmt = count_stmt.where(
+                orm_models.TransactionModel.timestamp <= to_date
+            )
+        count_result = await self._session.execute(count_stmt)
+        total = count_result.scalar_one()
+
+        stmt = sa.select(orm_models.TransactionModel)
+        if from_date is not None:
+            stmt = stmt.where(orm_models.TransactionModel.timestamp >= from_date)
+        if to_date is not None:
+            stmt = stmt.where(orm_models.TransactionModel.timestamp <= to_date)
+        stmt = stmt.order_by(orm_models.TransactionModel.timestamp).offset(offset)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        result = await self._session.execute(stmt)
+        rows = result.scalars().all()
+        return [mappers.transaction_to_domain(r) for r in rows], total

--- a/src/ledger/main.py
+++ b/src/ledger/main.py
@@ -5,6 +5,7 @@ import contextlib
 import os
 
 import fastapi
+import fastapi.middleware.cors as cors_middleware
 
 import ledger.api.exception_handlers as exception_handlers
 import ledger.api.routers.accounts as accounts_router
@@ -43,6 +44,17 @@ def create_app() -> fastapi.FastAPI:
         description="Double-entry bookkeeping financial ledger system",
         version="0.1.0",
         lifespan=lifespan,
+    )
+
+    cors_origins = os.environ.get(
+        "CORS_ORIGINS", "http://localhost:5173,http://localhost:3000"
+    )
+    app.add_middleware(
+        cors_middleware.CORSMiddleware,
+        allow_origins=[o.strip() for o in cors_origins.split(",") if o.strip()],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
     )
 
     exception_handlers.register_exception_handlers(app)

--- a/src/ledger/scripts/seed.py
+++ b/src/ledger/scripts/seed.py
@@ -194,7 +194,7 @@ async def seed(
     # --- summary ---
     async with session_factory() as session:
         acct_repo = account_repo_mod.SqlaAccountRepository(session)
-        results = await acct_repo.get_all_with_balances()
+        results, total = await acct_repo.get_all_with_balances()
 
     print("Seed data loaded successfully!")
     print()

--- a/tests/api/test_accounts_api.py
+++ b/tests/api/test_accounts_api.py
@@ -70,11 +70,15 @@ async def test_create_account_invalid_type(client: httpx.AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_get_all_accounts_empty(client: httpx.AsyncClient) -> None:
-    """GET /api/accounts with no data returns 200 and empty list."""
+    """GET /api/accounts with no data returns 200 and empty envelope."""
     response = await client.get("/api/accounts")
 
     assert response.status_code == 200
-    assert response.json() == []
+    body = response.json()
+    assert body["items"] == []
+    assert body["total"] == 0
+    assert body["limit"] is None
+    assert body["offset"] == 0
 
 
 @pytest.mark.asyncio
@@ -124,7 +128,9 @@ async def test_get_all_accounts_with_balances(
     response = await client.get("/api/accounts")
 
     assert response.status_code == 200
-    accounts = response.json()
+    body = response.json()
+    assert body["total"] == 2
+    accounts = body["items"]
     assert len(accounts) == 2
 
     accounts_by_name = {a["name"]: a for a in accounts}
@@ -204,7 +210,9 @@ async def test_get_all_accounts_balances_after_transactions(
     response = await client.get("/api/accounts")
 
     assert response.status_code == 200
-    accounts = {a["name"]: a for a in response.json()}
+    body = response.json()
+    assert body["total"] == 2
+    accounts = {a["name"]: a for a in body["items"]}
     assert accounts["Cash"]["balance"] == "800.00"
     assert accounts["Revenue"]["balance"] == "800.00"
 
@@ -218,7 +226,11 @@ async def test_list_accounts_with_limit(client: httpx.AsyncClient) -> None:
     response = await client.get("/api/accounts", params={"limit": 2})
 
     assert response.status_code == 200
-    assert len(response.json()) == 2
+    body = response.json()
+    assert len(body["items"]) == 2
+    assert body["total"] == 3
+    assert body["limit"] == 2
+    assert body["offset"] == 0
 
 
 @pytest.mark.asyncio
@@ -230,9 +242,12 @@ async def test_list_accounts_with_offset(client: httpx.AsyncClient) -> None:
     response = await client.get("/api/accounts", params={"offset": 1})
 
     assert response.status_code == 200
-    names = [a["name"] for a in response.json()]
+    body = response.json()
+    names = [a["name"] for a in body["items"]]
     assert "Alpha" not in names
     assert len(names) == 2
+    assert body["total"] == 3
+    assert body["offset"] == 1
 
 
 @pytest.mark.asyncio
@@ -244,7 +259,9 @@ async def test_list_accounts_no_limit_returns_all(client: httpx.AsyncClient) -> 
     response = await client.get("/api/accounts")
 
     assert response.status_code == 200
-    assert len(response.json()) == 3
+    body = response.json()
+    assert len(body["items"]) == 3
+    assert body["total"] == 3
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_cors.py
+++ b/tests/api/test_cors.py
@@ -1,0 +1,62 @@
+"""API tests for CORS middleware configuration."""
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_cors_allows_configured_origin(client: httpx.AsyncClient) -> None:
+    """Preflight request from allowed origin returns CORS headers."""
+    response = await client.options(
+        "/api/accounts",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:5173"
+
+
+@pytest.mark.asyncio
+async def test_cors_allows_second_configured_origin(
+    client: httpx.AsyncClient,
+) -> None:
+    """Preflight request from second allowed origin returns CORS headers."""
+    response = await client.options(
+        "/api/accounts",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+
+
+@pytest.mark.asyncio
+async def test_cors_blocks_unknown_origin(client: httpx.AsyncClient) -> None:
+    """Preflight request from unknown origin does not return allow header."""
+    response = await client.options(
+        "/api/accounts",
+        headers={
+            "Origin": "http://evil.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert "access-control-allow-origin" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_cors_simple_get_includes_headers(client: httpx.AsyncClient) -> None:
+    """Simple GET with Origin header includes CORS response headers."""
+    response = await client.get(
+        "/api/accounts",
+        headers={"Origin": "http://localhost:5173"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:5173"

--- a/tests/api/test_transactions_api.py
+++ b/tests/api/test_transactions_api.py
@@ -290,7 +290,9 @@ async def test_get_transactions_for_account(client: httpx.AsyncClient) -> None:
     response = await client.get(f"/api/accounts/{cash_id}/transactions")
 
     assert response.status_code == 200
-    txns = response.json()
+    body = response.json()
+    assert body["total"] == 2
+    txns = body["items"]
     assert len(txns) == 2
     descriptions = {t["description"] for t in txns}
     assert descriptions == {"First sale", "Second sale"}
@@ -334,7 +336,10 @@ async def test_get_account_transactions_with_limit(
     )
 
     assert response.status_code == 200
-    assert len(response.json()) == 1
+    body = response.json()
+    assert len(body["items"]) == 1
+    assert body["total"] == 3
+    assert body["limit"] == 1
 
 
 @pytest.mark.asyncio
@@ -363,7 +368,10 @@ async def test_get_account_transactions_with_offset(
     )
 
     assert response.status_code == 200
-    assert len(response.json()) == 2
+    body = response.json()
+    assert len(body["items"]) == 2
+    assert body["total"] == 3
+    assert body["offset"] == 1
 
 
 @pytest.mark.asyncio
@@ -393,8 +401,10 @@ async def test_get_account_transactions_with_from_date(
     )
 
     assert response.status_code == 200
-    txns = response.json()
+    body = response.json()
+    txns = body["items"]
     assert len(txns) == 2
+    assert body["total"] == 2
     descriptions = {t["description"] for t in txns}
     assert "Sale 1" not in descriptions
 
@@ -426,8 +436,10 @@ async def test_get_account_transactions_with_to_date(
     )
 
     assert response.status_code == 200
-    txns = response.json()
+    body = response.json()
+    txns = body["items"]
     assert len(txns) == 2
+    assert body["total"] == 2
     descriptions = {t["description"] for t in txns}
     assert "Sale 3" not in descriptions
 
@@ -462,7 +474,109 @@ async def test_get_account_transactions_with_date_range(
     )
 
     assert response.status_code == 200
-    txns = response.json()
+    body = response.json()
+    txns = body["items"]
     assert len(txns) == 3
+    assert body["total"] == 3
     descriptions = {t["description"] for t in txns}
     assert descriptions == {"Sale 2", "Sale 3", "Sale 4"}
+
+
+@pytest.mark.asyncio
+async def test_list_all_transactions_empty(client: httpx.AsyncClient) -> None:
+    """GET /api/transactions with no data returns empty envelope."""
+    response = await client.get("/api/transactions")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"] == []
+    assert body["total"] == 0
+    assert body["limit"] is None
+    assert body["offset"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_all_transactions(client: httpx.AsyncClient) -> None:
+    """GET /api/transactions returns all transactions in envelope."""
+    cash_id = await _create_account(client, "Cash", "ASSET")
+    revenue_id = await _create_account(client, "Revenue", "REVENUE")
+
+    for i in range(3):
+        await client.post(
+            "/api/transactions",
+            json={
+                "description": f"Sale {i + 1}",
+                "date": f"2025-01-0{i + 1}T10:00:00",
+                "entries": [
+                    {"accountId": cash_id, "type": "DEBIT", "amount": 100.00},
+                    {"accountId": revenue_id, "type": "CREDIT", "amount": 100.00},
+                ],
+            },
+        )
+
+    response = await client.get("/api/transactions")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 3
+    assert body["total"] == 3
+
+
+@pytest.mark.asyncio
+async def test_list_all_transactions_with_limit(client: httpx.AsyncClient) -> None:
+    """GET /api/transactions?limit=1 returns at most 1 transaction."""
+    cash_id = await _create_account(client, "Cash", "ASSET")
+    revenue_id = await _create_account(client, "Revenue", "REVENUE")
+
+    for i in range(3):
+        await client.post(
+            "/api/transactions",
+            json={
+                "description": f"Sale {i + 1}",
+                "date": f"2025-01-0{i + 1}T10:00:00",
+                "entries": [
+                    {"accountId": cash_id, "type": "DEBIT", "amount": 100.00},
+                    {"accountId": revenue_id, "type": "CREDIT", "amount": 100.00},
+                ],
+            },
+        )
+
+    response = await client.get("/api/transactions", params={"limit": 1})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 1
+    assert body["total"] == 3
+    assert body["limit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_all_transactions_with_date_filter(
+    client: httpx.AsyncClient,
+) -> None:
+    """GET /api/transactions with date filters returns matching transactions."""
+    cash_id = await _create_account(client, "Cash", "ASSET")
+    revenue_id = await _create_account(client, "Revenue", "REVENUE")
+
+    for i in range(3):
+        await client.post(
+            "/api/transactions",
+            json={
+                "description": f"Sale {i + 1}",
+                "date": f"2025-01-0{i + 1}T10:00:00",
+                "entries": [
+                    {"accountId": cash_id, "type": "DEBIT", "amount": 100.00},
+                    {"accountId": revenue_id, "type": "CREDIT", "amount": 100.00},
+                ],
+            },
+        )
+
+    response = await client.get(
+        "/api/transactions",
+        params={"from_date": "2025-01-02T00:00:00"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 2
+    assert body["total"] == 2

--- a/tests/integration/test_account_repo.py
+++ b/tests/integration/test_account_repo.py
@@ -145,16 +145,17 @@ class TestAccountRepoPagination:
     async def test_limit_restricts_result_count(
         self, db_session: sa_async.AsyncSession
     ) -> None:
-        """get_all_with_balances with limit=2 returns at most 2 accounts."""
+        """get_all_with_balances with limit=2 returns at most 2 items."""
         repo = account_repo_mod.SqlaAccountRepository(db_session)
         for name in ["Alpha", "Bravo", "Charlie"]:
             await repo.create(
                 models.Account(id=uuid.uuid4(), name=name, type=enums.AccountType.ASSET)
             )
 
-        result = await repo.get_all_with_balances(limit=2)
+        items, total = await repo.get_all_with_balances(limit=2)
 
-        assert len(result) == 2
+        assert len(items) == 2
+        assert total == 3
 
     async def test_offset_skips_rows(self, db_session: sa_async.AsyncSession) -> None:
         """offset=1 skips first account (ordered by name)."""
@@ -164,11 +165,12 @@ class TestAccountRepoPagination:
                 models.Account(id=uuid.uuid4(), name=name, type=enums.AccountType.ASSET)
             )
 
-        result = await repo.get_all_with_balances(offset=1)
+        items, total = await repo.get_all_with_balances(offset=1)
 
-        names = [account.name for account, _ in result]
+        names = [account.name for account, _ in items]
         assert "Alpha" not in names
         assert len(names) == 2
+        assert total == 3
 
     async def test_no_limit_returns_all(
         self, db_session: sa_async.AsyncSession
@@ -180,6 +182,22 @@ class TestAccountRepoPagination:
                 models.Account(id=uuid.uuid4(), name=name, type=enums.AccountType.ASSET)
             )
 
-        result = await repo.get_all_with_balances()
+        items, total = await repo.get_all_with_balances()
 
-        assert len(result) == 3
+        assert len(items) == 3
+        assert total == 3
+
+    async def test_total_reflects_full_count(
+        self, db_session: sa_async.AsyncSession
+    ) -> None:
+        """total reflects full count regardless of limit/offset."""
+        repo = account_repo_mod.SqlaAccountRepository(db_session)
+        for name in ["Alpha", "Bravo", "Charlie", "Delta", "Echo"]:
+            await repo.create(
+                models.Account(id=uuid.uuid4(), name=name, type=enums.AccountType.ASSET)
+            )
+
+        items, total = await repo.get_all_with_balances(limit=2, offset=1)
+
+        assert len(items) == 2
+        assert total == 5

--- a/tests/integration/test_balance_integration.py
+++ b/tests/integration/test_balance_integration.py
@@ -255,8 +255,9 @@ async def test_cumulative_multiple_transactions(
     assert cash_balance == decimal.Decimal("600.00")
 
     # Verify get_all_with_balances
-    all_results = await repo.get_all_with_balances()
-    balances = {account.name: balance for account, balance in all_results}
+    all_items, all_total = await repo.get_all_with_balances()
+    assert all_total == 3
+    balances = {account.name: balance for account, balance in all_items}
     assert balances["Cash"] == decimal.Decimal("600.00")
     assert balances["Revenue"] == decimal.Decimal("800.00")
     assert balances["Supplies"] == decimal.Decimal("200.00")

--- a/tests/integration/test_seed.py
+++ b/tests/integration/test_seed.py
@@ -54,9 +54,10 @@ async def test_seed_creates_accounts_with_correct_balances(
 
     async with session_factory() as session:
         repo = account_repo_mod.SqlaAccountRepository(session)
-        results = await repo.get_all_with_balances()
-        balances = {account.name: balance for account, balance in results}
+        items, total = await repo.get_all_with_balances()
+        balances = {account.name: balance for account, balance in items}
 
+    assert total == len(EXPECTED_BALANCES)
     assert len(balances) == len(EXPECTED_BALANCES)
     for name, expected in EXPECTED_BALANCES.items():
         assert balances[name] == expected, f"{name}: {balances[name]} != {expected}"
@@ -74,9 +75,10 @@ async def test_seed_is_idempotent(
 
     async with session_factory() as session:
         repo = account_repo_mod.SqlaAccountRepository(session)
-        results = await repo.get_all_with_balances()
-        balances = {account.name: balance for account, balance in results}
+        items, total = await repo.get_all_with_balances()
+        balances = {account.name: balance for account, balance in items}
 
+    assert total == len(EXPECTED_BALANCES)
     assert len(balances) == len(EXPECTED_BALANCES)
     for name, expected in EXPECTED_BALANCES.items():
         assert balances[name] == expected, f"{name}: {balances[name]} != {expected}"

--- a/tests/integration/test_transaction_repo.py
+++ b/tests/integration/test_transaction_repo.py
@@ -190,10 +190,11 @@ class TestTransactionRepoGetByAccountId:
         txn = _make_transaction(cash.id, revenue.id)
         await repo.create(txn)
 
-        result = await repo.get_by_account_id(cash.id)
+        items, total = await repo.get_by_account_id(cash.id)
 
-        assert len(result) == 1
-        assert result[0].id == txn.id
+        assert len(items) == 1
+        assert items[0].id == txn.id
+        assert total == 1
 
     async def test_get_by_account_id_preserves_all_entries(
         self,
@@ -206,9 +207,10 @@ class TestTransactionRepoGetByAccountId:
         txn = _make_transaction(cash.id, revenue.id)
         await repo.create(txn)
 
-        result = await repo.get_by_account_id(cash.id)
+        items, total = await repo.get_by_account_id(cash.id)
 
-        assert len(result[0].entries) == 2
+        assert len(items[0].entries) == 2
+        assert total == 1
 
     async def test_get_by_account_id_empty(
         self,
@@ -217,9 +219,10 @@ class TestTransactionRepoGetByAccountId:
         """get_by_account_id returns empty list for an account with no transactions."""
         repo = txn_repo_mod.SqlaTransactionRepository(db_session)
 
-        result = await repo.get_by_account_id(uuid.uuid4())
+        items, total = await repo.get_by_account_id(uuid.uuid4())
 
-        assert result == []
+        assert items == []
+        assert total == 0
 
 
 class TestTransactionRepoPaginationAndFiltering:
@@ -242,9 +245,10 @@ class TestTransactionRepoPaginationAndFiltering:
             )
             await repo.create(txn)
 
-        result = await repo.get_by_account_id(cash.id, limit=1)
+        items, total = await repo.get_by_account_id(cash.id, limit=1)
 
-        assert len(result) == 1
+        assert len(items) == 1
+        assert total == 3
 
     async def test_offset_skips_rows(
         self,
@@ -263,9 +267,10 @@ class TestTransactionRepoPaginationAndFiltering:
             )
             await repo.create(txn)
 
-        result = await repo.get_by_account_id(cash.id, offset=1)
+        items, total = await repo.get_by_account_id(cash.id, offset=1)
 
-        assert len(result) == 2
+        assert len(items) == 2
+        assert total == 3
 
     async def test_from_date_filters_transactions(
         self,
@@ -284,14 +289,15 @@ class TestTransactionRepoPaginationAndFiltering:
             )
             await repo.create(txn)
 
-        result = await repo.get_by_account_id(
+        items, total = await repo.get_by_account_id(
             cash.id,
             from_date=datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
         )
 
-        assert len(result) == 2
-        descriptions = {t.description for t in result}
+        assert len(items) == 2
+        descriptions = {t.description for t in items}
         assert "Sale 1" not in descriptions
+        assert total == 2
 
     async def test_to_date_filters_transactions(
         self,
@@ -310,14 +316,15 @@ class TestTransactionRepoPaginationAndFiltering:
             )
             await repo.create(txn)
 
-        result = await repo.get_by_account_id(
+        items, total = await repo.get_by_account_id(
             cash.id,
             to_date=datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
         )
 
-        assert len(result) == 2
-        descriptions = {t.description for t in result}
+        assert len(items) == 2
+        descriptions = {t.description for t in items}
         assert "Sale 3" not in descriptions
+        assert total == 2
 
     async def test_date_range_filters_transactions(
         self,
@@ -336,15 +343,16 @@ class TestTransactionRepoPaginationAndFiltering:
             )
             await repo.create(txn)
 
-        result = await repo.get_by_account_id(
+        items, total = await repo.get_by_account_id(
             cash.id,
             from_date=datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
             to_date=datetime.datetime(2025, 1, 4, tzinfo=datetime.UTC),
         )
 
-        assert len(result) == 3
-        descriptions = {t.description for t in result}
+        assert len(items) == 3
+        descriptions = {t.description for t in items}
         assert descriptions == {"Sale 2", "Sale 3", "Sale 4"}
+        assert total == 3
 
     async def test_no_limit_returns_all(
         self,
@@ -363,6 +371,118 @@ class TestTransactionRepoPaginationAndFiltering:
             )
             await repo.create(txn)
 
-        result = await repo.get_by_account_id(cash.id)
+        items, total = await repo.get_by_account_id(cash.id)
 
-        assert len(result) == 3
+        assert len(items) == 3
+        assert total == 3
+
+    async def test_total_reflects_filtered_count(
+        self,
+        db_session: sa_async.AsyncSession,
+        two_accounts: tuple[models.Account, models.Account],
+    ) -> None:
+        """total reflects count after date filters but before limit/offset."""
+        cash, revenue = two_accounts
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+        for i in range(5):
+            txn = _make_transaction_with_timestamp(
+                cash.id,
+                revenue.id,
+                datetime.datetime(2025, 1, i + 1, tzinfo=datetime.UTC),
+                description=f"Sale {i + 1}",
+            )
+            await repo.create(txn)
+
+        items, total = await repo.get_by_account_id(
+            cash.id,
+            limit=1,
+            from_date=datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
+            to_date=datetime.datetime(2025, 1, 4, tzinfo=datetime.UTC),
+        )
+
+        assert len(items) == 1
+        assert total == 3
+
+
+class TestTransactionRepoGetAll:
+    """Tests for SqlaTransactionRepository.get_all()."""
+
+    async def test_get_all_empty(
+        self,
+        db_session: sa_async.AsyncSession,
+    ) -> None:
+        """get_all returns empty list and zero total when no transactions exist."""
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+
+        items, total = await repo.get_all()
+
+        assert items == []
+        assert total == 0
+
+    async def test_get_all_returns_all_transactions(
+        self,
+        db_session: sa_async.AsyncSession,
+        two_accounts: tuple[models.Account, models.Account],
+    ) -> None:
+        """get_all returns all transactions with entries."""
+        cash, revenue = two_accounts
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+        for i in range(3):
+            txn = _make_transaction_with_timestamp(
+                cash.id,
+                revenue.id,
+                datetime.datetime(2025, 1, i + 1, tzinfo=datetime.UTC),
+                description=f"Sale {i + 1}",
+            )
+            await repo.create(txn)
+
+        items, total = await repo.get_all()
+
+        assert len(items) == 3
+        assert total == 3
+
+    async def test_get_all_with_limit(
+        self,
+        db_session: sa_async.AsyncSession,
+        two_accounts: tuple[models.Account, models.Account],
+    ) -> None:
+        """get_all with limit returns limited items but full total."""
+        cash, revenue = two_accounts
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+        for i in range(3):
+            txn = _make_transaction_with_timestamp(
+                cash.id,
+                revenue.id,
+                datetime.datetime(2025, 1, i + 1, tzinfo=datetime.UTC),
+                description=f"Sale {i + 1}",
+            )
+            await repo.create(txn)
+
+        items, total = await repo.get_all(limit=2)
+
+        assert len(items) == 2
+        assert total == 3
+
+    async def test_get_all_with_date_filter(
+        self,
+        db_session: sa_async.AsyncSession,
+        two_accounts: tuple[models.Account, models.Account],
+    ) -> None:
+        """get_all with date filters returns only matching transactions."""
+        cash, revenue = two_accounts
+        repo = txn_repo_mod.SqlaTransactionRepository(db_session)
+        for i in range(3):
+            txn = _make_transaction_with_timestamp(
+                cash.id,
+                revenue.id,
+                datetime.datetime(2025, 1, i + 1, tzinfo=datetime.UTC),
+                description=f"Sale {i + 1}",
+            )
+            await repo.create(txn)
+
+        items, total = await repo.get_all(
+            from_date=datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
+        )
+
+        assert len(items) == 2
+        assert total == 2


### PR DESCRIPTION
## Summary
- List endpoints (`GET /api/accounts`, `GET /api/accounts/{id}/transactions`, new `GET /api/transactions`) now return `{items, total, limit, offset}` envelopes for frontend pagination controls
- Added `GET /api/transactions` endpoint for global transaction listing with pagination and date filtering
- Added CORS middleware configurable via `CORS_ORIGINS` env var (defaults to `localhost:5173,3000`)

## Changes
- **New:** `src/ledger/application/pagination.py` — `PaginatedResult[T]` frozen dataclass
- **New:** `tests/api/test_cors.py` — 4 CORS middleware tests
- **Modified:** Repository layer returns `(items, total)` tuples with separate COUNT queries
- **Modified:** Services return `PaginatedResult` instead of bare lists
- **Modified:** API schemas include `PaginatedAccountResponse` and `PaginatedTransactionResponse`
- **Modified:** `main.py` adds `CORSMiddleware`
- **Docs:** Updated api-specification.md, architecture.md, docs/README.md

## Test plan
- [x] All 132 tests pass (`make check`)
- [x] Lint, format, typecheck all green
- [ ] Verify CI passes on PR
- [ ] Manual smoke test with frontend

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)