### PR TITLE
docs: mention frontend URL in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cd illuminati
 docker compose up -d
 ```
 
-The app starts at `http://localhost:8000`. Database migrations run automatically on first startup.
+The API starts at `http://localhost:8000` and the frontend at `http://localhost:3000`. Database migrations run automatically on first startup.
 
 Verify it works:
 


### PR DESCRIPTION
## Summary
- Add `http://localhost:3000` frontend URL alongside the existing API URL in the Quick Start section

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `docker compose up -d` serves frontend at port 3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)